### PR TITLE
fix: add Node.js 20 runtime to backend for yt-dlp compatibility

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,12 +3,19 @@ FROM python:3.11-slim
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies
+# Install system dependencies including curl for Node.js installer
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     ffmpeg \
+    curl \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20+ for yt-dlp JavaScript runtime requirement
+# yt-dlp now requires a JS runtime (Node/Deno/Bun) to execute YouTube player code
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
 COPY requirements.txt .


### PR DESCRIPTION
yt-dlp now requires a JavaScript runtime (Node.js 20+, Deno, Bun, or QuickJS) to execute YouTube's player code for video URL extraction. This change adds Node.js 20 to the development backend Docker container.

Why Node.js instead of Deno:
- Maintains consistency with production Dockerfile (already has Node.js 18)
- Matches frontend runtime (Next.js uses Node.js)
- Simpler troubleshooting with larger community support
- Security isolation via Docker is sufficient for personal use case

Related to yt-dlp issue: https://github.com/yt-dlp/yt-dlp/issues/14404