### PR TITLE
Fix Alembic multiple migration heads conflict

### DIFF
--- a/backend/alembic/versions/f9g8h7i6j5k4_merge_nfo_and_scheduler_branches.py
+++ b/backend/alembic/versions/f9g8h7i6j5k4_merge_nfo_and_scheduler_branches.py
@@ -1,0 +1,46 @@
+"""merge NFO and scheduler branches
+
+This is a merge migration that combines two divergent branches:
+- Branch 1: NFO file generation tracking (e8f7g6h5i4j3)
+- Branch 2: File tracking and scheduler configuration (d4e9f5a6b7c8)
+
+Both branches diverged from c3d8f2e5a9b4 (metadata management).
+This merge brings them back together into a single migration head.
+
+Revision ID: f9g8h7i6j5k4
+Revises: d4e9f5a6b7c8, e8f7g6h5i4j3
+Create Date: 2025-11-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f9g8h7i6j5k4'
+down_revision: Union[str, Sequence[str], None] = ('d4e9f5a6b7c8', 'e8f7g6h5i4j3')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Merge migration - no schema changes needed.
+
+    Both branches made independent changes to different parts of the schema:
+    - NFO branch: Added nfo_last_generated to channels table
+    - Scheduler branch: Added scheduler settings and file tracking
+
+    No conflicts exist, so this merge migration is empty.
+    """
+    pass
+
+
+def downgrade() -> None:
+    """
+    Downgrade splits back into two heads.
+
+    This is the reverse of a merge - it recreates the branch point.
+    """
+    pass


### PR DESCRIPTION
The application was failing to start due to multiple head revisions in the Alembic migration history. This occurred when two feature branches (NFO generation and scheduler configuration) were both merged to main without properly merging their migration histories.

Root Cause:
- Branch 1 (NFO): e8f7g6h5i4j3 added NFO tracking to channels
- Branch 2 (Scheduler): d4e9f5a6b7c8 added scheduler settings
- Both diverged from c3d8f2e5a9b4 (metadata management)
- When both merged, Alembic saw two "head" revisions instead of one

Solution:
Created merge migration f9g8h7i6j5k4 that combines both heads into a single revision. This migration has both previous heads as down_revisions, effectively merging the two branches back together.

The merge migration is empty (no schema changes) because the two branches modified different parts of the schema with no conflicts:
- NFO branch: channels.nfo_last_generated column
- Scheduler branch: application_settings scheduler keys + downloads tracking

Fixes startup error:
"Multiple head revisions are present for given argument 'head'"