### PR TITLE
feat: add NFO generation settings management endpoints

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -436,13 +436,23 @@ def initialize_default_settings(db_session) -> bool:
             },
             {
                 'key': 'default_quality_preset',
-                'value': 'best', 
+                'value': 'best',
                 'description': 'Default video quality preset for new channels (best, 1080p, 720p, 480p).'
             },
             {
                 'key': 'default_schedule',
                 'value': '0 0 * * *',
                 'description': 'Default cron schedule for channel monitoring (daily at midnight UTC).'
+            },
+            {
+                'key': 'nfo_enabled',
+                'value': 'true',
+                'description': 'Enable/disable NFO file generation for new video downloads. NFO files provide Jellyfin-compatible metadata.'
+            },
+            {
+                'key': 'nfo_overwrite_existing',
+                'value': 'false',
+                'description': 'Overwrite existing NFO files during regeneration. Set to true to force update all NFO files.'
             }
         ]
         


### PR DESCRIPTION
Added missing GET and PUT endpoints for managing NFO generation settings in the Settings UI. This fixes the 404 error when toggling NFO settings.

Changes:

1. Added NFO settings initialization (backend/app/utils.py)
   - nfo_enabled: Enable/disable NFO generation (default: true)
   - nfo_overwrite_existing: Overwrite existing NFO files (default: false)
   - Settings automatically initialized on app startup

2. Added GET /api/v1/settings/nfo endpoint (backend/app/api.py)
   - Returns current NFO generation settings
   - Includes enabled and overwrite_existing flags
   - Provides setting descriptions for UI display

3. Added PUT /api/v1/settings/nfo endpoint (backend/app/api.py)
   - Updates NFO generation settings
   - Validates input and syncs to YAML config
   - Returns updated settings with confirmation message

Settings UI Impact:
The Settings page NFO section now works correctly:
- Toggle "Enable NFO Generation" checkbox
- Toggle "Overwrite Existing Files" checkbox
- Changes are saved to database and YAML config
- Real-time feedback with success/error messages

NFO Settings Behavior:
- nfo_enabled: Controls whether new video downloads generate NFO files
- nfo_overwrite_existing: Controls whether regeneration overwrites existing files
- Both settings sync between database and YAML configuration

Fixes: 404 error on PUT /api/v1/settings/nfo