### PR TITLE
feat: update season.nfo to always use January 1st for premiered date

### DIFF
--- a/backend/app/nfo_service.py
+++ b/backend/app/nfo_service.py
@@ -303,10 +303,13 @@ class NFOService:
         """
         Create season.nfo XML content for year-based seasons.
 
-        Season NFO is minimal - Jellyfin just needs:
-        - Title: The year (e.g., "2021")
-        - Season number: The year (e.g., 2021)
+        Season NFO includes:
+        - Title: The year (e.g., "2025")
+        - Season number: The year (e.g., 2025)
+        - Premiered: Always January 1st of the year (e.g., "2025-01-01")
+        - Release date: Same as premiered
         - Date added: Current timestamp
+        - Lock data: Set to false (allows Jellyfin to update metadata)
 
         Args:
             year: Year string (e.g., "2021")
@@ -321,17 +324,27 @@ class NFOService:
         ET.SubElement(root, 'plot')
         ET.SubElement(root, 'outline')
 
+        # Lock data: false allows Jellyfin to update metadata if needed
+        ET.SubElement(root, 'lockdata').text = 'false'
+
         # Current timestamp for when season was created
         dateadded = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         ET.SubElement(root, 'dateadded').text = dateadded
 
-        # Title and season number both use the year
-        # Why year as season number? Makes chronological sorting natural in Jellyfin
+        # Title and year both use the year value
         ET.SubElement(root, 'title').text = str(year)
-        ET.SubElement(root, 'season').text = str(year)
+        ET.SubElement(root, 'year').text = str(year)
 
-        # Empty art tag (no custom season artwork)
-        ET.SubElement(root, 'art')
+        # Premiered and releasedate: Always January 1st of the year
+        # Why January 1st? Provides consistent date for season organization
+        # regardless of when first video was actually uploaded
+        jan_first = f"{year}-01-01"
+        ET.SubElement(root, 'premiered').text = jan_first
+        ET.SubElement(root, 'releasedate').text = jan_first
+
+        # Season number: Use the year for chronological sorting
+        ET.SubElement(root, 'seasonnumber').text = str(year)
+        ET.SubElement(root, 'season').text = str(year)
 
         return self._prettify_xml(root)
 

--- a/backend/tests/integration/test_nfo_integration.py
+++ b/backend/tests/integration/test_nfo_integration.py
@@ -228,6 +228,12 @@ class TestNFOGenerationTriggeredByDownload:
         assert root.tag == 'season'
         assert root.find('title').text == '2025'
         assert root.find('season').text == '2025'
+        # Verify new fields (premiered should be January 1st of the year)
+        assert root.find('premiered').text == '2025-01-01'
+        assert root.find('releasedate').text == '2025-01-01'
+        assert root.find('year').text == '2025'
+        assert root.find('seasonnumber').text == '2025'
+        assert root.find('lockdata').text == 'false'
 
     def test_existing_season_nfo_not_overwritten(
         self,

--- a/backend/tests/unit/test_nfo_service.py
+++ b/backend/tests/unit/test_nfo_service.py
@@ -736,8 +736,10 @@ class TestSeasonNFOGeneration:
 
         Validates:
         - All required tags are present
-        - Empty tags (plot, outline, art) are included
+        - Empty tags (plot, outline) are included
         - dateadded has correct format
+        - premiered and releasedate are always January 1st of the year
+        - lockdata is set to 'false'
         """
         # Setup
         year_dir = os.path.join(temp_media_dir, "Channel", "2023")
@@ -755,14 +757,31 @@ class TestSeasonNFOGeneration:
         # Required elements exist
         assert root.find('plot') is not None
         assert root.find('outline') is not None
-        assert root.find('title') is not None
-        assert root.find('season') is not None
+        assert root.find('lockdata') is not None
         assert root.find('dateadded') is not None
-        assert root.find('art') is not None
+        assert root.find('title') is not None
+        assert root.find('year') is not None
+        assert root.find('premiered') is not None
+        assert root.find('releasedate') is not None
+        assert root.find('seasonnumber') is not None
+        assert root.find('season') is not None
 
         # Empty elements
         assert root.find('plot').text is None or root.find('plot').text == ''
         assert root.find('outline').text is None or root.find('outline').text == ''
+
+        # lockdata should be 'false'
+        assert root.find('lockdata').text == 'false'
+
+        # Year fields should match directory year
+        assert root.find('title').text == '2023'
+        assert root.find('year').text == '2023'
+        assert root.find('seasonnumber').text == '2023'
+        assert root.find('season').text == '2023'
+
+        # premiered and releasedate should always be January 1st of the year
+        assert root.find('premiered').text == '2023-01-01'
+        assert root.find('releasedate').text == '2023-01-01'
 
         # dateadded format: YYYY-MM-DD HH:MM:SS
         dateadded = root.find('dateadded').text


### PR DESCRIPTION
Enhanced season.nfo generation to include additional Jellyfin metadata fields
and set premiered/releasedate to always be January 1st of the year instead of
the actual first video upload date. This provides more consistent season
organization in Jellyfin.

Changes:
- Added <lockdata>false</lockdata> to allow Jellyfin metadata updates
- Added <year> tag with year value
- Added <premiered> and <releasedate> tags (always set to YYYY-01-01)
- Added <seasonnumber> tag with year value
- Removed unused <art> tag

Updated tests to verify new season.nfo structure and validate that
premiered/releasedate are always set to January 1st of the respective year.