### PR TITLE
Change TVShow NFO generator to use genre tags

### DIFF
--- a/backend/app/nfo_service.py
+++ b/backend/app/nfo_service.py
@@ -424,7 +424,7 @@ class NFOService:
         description   → <plot>            | Channel description
         id/channel_id → <uniqueid>        | YouTube channel ID
         hardcoded     → <studio>          | Always "YouTube"
-        tags[]        → <tag>             | One tag per tag
+        tags[]        → <genre>           | One genre per tag
 
         Args:
             channel_info: Dictionary from channel .info.json file
@@ -455,10 +455,10 @@ class NFOService:
         # Studio: Always YouTube
         ET.SubElement(root, 'studio').text = 'YouTube'
 
-        # Channel tags → tags only (no genres)
-        # Why tags only? Simpler metadata structure, tags are more specific
+        # Channel tags → genres
+        # Why genres? Better semantic match for Jellyfin categorization
         for tag in channel_info.get('tags', []):
-            ET.SubElement(root, 'tag').text = tag
+            ET.SubElement(root, 'genre').text = tag
 
         return self._prettify_xml(root)
 

--- a/backend/tests/unit/test_nfo_service.py
+++ b/backend/tests/unit/test_nfo_service.py
@@ -137,7 +137,7 @@ def sample_channel_info():
 
     Important: Channel metadata does NOT have 'categories' field
     (only episode-level metadata has categories).
-    Tags are mapped to both genres and tags.
+    Tags are mapped to genres in tvshow.nfo.
     """
     return {
         "id": "UCzGzk0K7GLJ_edZu4u3TyUg",
@@ -815,7 +815,7 @@ class TestTvshowNFOGeneration:
         - Channel name maps to title
         - Description is included
         - Unique ID is included
-        - Tags are included (no genres)
+        - Genres are included (not tags)
         - Studio is "YouTube"
         """
         # Setup: Create channel directory and metadata file
@@ -853,14 +853,14 @@ class TestTvshowNFOGeneration:
         assert uniqueid.get('default') == 'true'
         assert uniqueid.text == sample_channel_info['id']
 
-        # Verify: Tags only (no genres)
+        # Verify: Genres (not tags)
         genres = [g.text for g in root.findall('genre')]
         tags = [t.text for t in root.findall('tag')]
 
-        assert len(genres) == 0, "Genres should not be present"
+        assert len(tags) == 0, "Tags should not be present"
 
         for tag in sample_channel_info['tags']:
-            assert tag in tags, f"{tag} not in tags"
+            assert tag in genres, f"{tag} not in genres"
 
     def test_tvshow_nfo_generation_with_minimal_metadata(
         self,


### PR DESCRIPTION
Changed the tvshow.nfo generator to create <genre> XML elements instead of <tag> elements when processing channel tags. This provides better semantic categorization in Jellyfin.

Changes:
- Updated _create_tvshow_nfo_xml() to use ET.SubElement(root, 'genre')
- Updated docstring to reflect tags[] → <genre> mapping
- Updated unit tests to verify <genre> tags are present
- Updated test assertions to expect genres instead of tags

Why this change?
- <genre> tags provide better semantic matching for Jellyfin categorization
- Improves content discovery and filtering in the media library