### PR TITLE
debug: add verbose cookie verification logging during video download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # =============================================================================
 # Stage 1: Build Frontend
 # =============================================================================
-FROM node:18-alpine AS frontend-builder
+FROM node:20-alpine AS frontend-builder
 
 WORKDIR /app/frontend
 
@@ -47,8 +47,10 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js for running frontend (minimal installation)
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+# Install Node.js 20+ for running frontend AND yt-dlp EJS (External JavaScript)
+# yt-dlp requires Node.js 20+ to decode YouTube's obfuscated video tokens
+# See: https://github.com/yt-dlp/yt-dlp/wiki/EJS
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -954,7 +954,25 @@ class VideoDownloadService:
             # Configure yt-dlp for this specific video
             opts = self.download_opts.copy()
             video_url = f"https://www.youtube.com/watch?v={video_id}"
-            
+
+            # DEBUG: Verify cookies are being passed to yt-dlp
+            cookie_in_opts = opts.get('cookiefile')
+            if cookie_in_opts:
+                if os.path.exists(cookie_in_opts):
+                    cookie_size = os.path.getsize(cookie_in_opts)
+                    # Check cookie file format (first line should be Netscape header or comment)
+                    try:
+                        with open(cookie_in_opts, 'r') as f:
+                            first_line = f.readline().strip()
+                        logger.info(f"[COOKIE DEBUG] Passing cookies to yt-dlp: {cookie_in_opts} ({cookie_size} bytes)")
+                        logger.info(f"[COOKIE DEBUG] Cookie file first line: {first_line[:80]}...")
+                    except Exception as e:
+                        logger.warning(f"[COOKIE DEBUG] Could not read cookie file: {e}")
+                else:
+                    logger.error(f"[COOKIE DEBUG] Cookie file in opts but NOT FOUND on disk: {cookie_in_opts}")
+            else:
+                logger.warning(f"[COOKIE DEBUG] NO cookiefile in download options! This is the bug.")
+
             logger.info(f"Starting download: {video_title} ({video_id})")
             
             with yt_dlp.YoutubeDL(opts) as ydl:

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -71,7 +71,12 @@ class VideoDownloadService:
         # Based on exact parameters from TDD reference bash script
         # Added anti-bot detection headers
         # Multi-client fallback strategy to handle YouTube changes
+        #
+        # IMPORTANT: YouTube requires JavaScript execution to decode video tokens
+        # We enable Node.js as the JS runtime (requires Node.js 20+)
+        # See: https://github.com/yt-dlp/yt-dlp/wiki/EJS
         self.download_opts = {
+            'js_runtimes': 'node',  # Enable Node.js for EJS (External JavaScript)
             'paths': {
                 'temp': self.temp_path,
                 'home': self.media_path
@@ -126,6 +131,7 @@ class VideoDownloadService:
         # Query-only configuration for getting recent videos
         # Using flat-playlist approach for fast, lightweight video ID extraction
         self.query_opts = {
+            'js_runtimes': 'node',  # Enable Node.js for EJS (External JavaScript)
             'quiet': True,
             'no_warnings': True,
             'extract_flat': True,   # Flat playlist - only get IDs and titles (like --flat-playlist)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,9 @@ pydantic-settings==2.1.0
 python-multipart==0.0.6
 pyyaml==6.0.1
 apscheduler==3.10.4
-yt-dlp>=2025.09.26
+# yt-dlp with [default] extra includes yt-dlp-ejs for YouTube JavaScript decoding
+# See: https://github.com/yt-dlp/yt-dlp/wiki/EJS
+yt-dlp[default]>=2025.09.26
 websockets==12.0
 apprise==1.6.0
 python-dotenv==1.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,7 @@ apscheduler==3.10.4
 # yt-dlp with [default] extra includes yt-dlp-ejs for YouTube JavaScript decoding
 # See: https://github.com/yt-dlp/yt-dlp/wiki/EJS
 yt-dlp[default]>=2025.09.26
-websockets==12.0
+websockets>=13.0
 apprise==1.6.0
 python-dotenv==1.0.0
 black==23.11.0


### PR DESCRIPTION
Adds detailed logging to verify:
- Whether cookiefile is in download options
- Whether cookie file exists on disk at download time
- Cookie file size and first line (format verification)

This will help diagnose why downloads fail with bot detection
even though cookie file was found at service initialization.