### PR TITLE
fix: add js_runtimes config to resolve yt-dlp validation error

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 20+ for yt-dlp JavaScript runtime requirement
+# Install Node.js 25 for yt-dlp JavaScript runtime requirement
 # yt-dlp now requires a JS runtime (Node/Deno/Bun) to execute YouTube player code
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_25.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -99,7 +99,7 @@ class VideoDownloadService:
             'quiet': not is_debug,           # Suppress output unless DEBUG
             'noprogress': not is_debug,      # Hide progress bars unless DEBUG
             'no_warnings': not is_debug,     # Hide warnings unless DEBUG
-            'js_runtimes': {},  # Disable JS runtime (fixes yt-dlp >=2025.09.26 validation error)
+            'js_runtimes': {'node': {}},  # Use Node.js runtime (fixes yt-dlp >=2025.09.26 validation error)
             # NOTE: Removed extractor_args player_client override
             # yt-dlp 2025.09.26+ has smart automatic client selection that works better
             # than manual overrides. Let yt-dlp choose the optimal client for each video.
@@ -132,7 +132,7 @@ class VideoDownloadService:
             'extract_flat': True,   # Flat playlist - only get IDs and titles (like --flat-playlist)
             'ignoreerrors': True,
             'match_filter': self._filter_shorts,  # Filter out YouTube Shorts at extraction time
-            'js_runtimes': {},  # Disable JS runtime (fixes yt-dlp >=2025.09.26 validation error)
+            'js_runtimes': {'node': {}},  # Use Node.js runtime (fixes yt-dlp >=2025.09.26 validation error)
             # NOTE: Removed extractor_args player_client override
             # yt-dlp 2025.09.26+ automatically selects optimal client
             # Minimal headers to avoid bot detection during light queries

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -99,6 +99,7 @@ class VideoDownloadService:
             'quiet': not is_debug,           # Suppress output unless DEBUG
             'noprogress': not is_debug,      # Hide progress bars unless DEBUG
             'no_warnings': not is_debug,     # Hide warnings unless DEBUG
+            'js_runtimes': {},  # Disable JS runtime (fixes yt-dlp >=2025.09.26 validation error)
             # NOTE: Removed extractor_args player_client override
             # yt-dlp 2025.09.26+ has smart automatic client selection that works better
             # than manual overrides. Let yt-dlp choose the optimal client for each video.
@@ -131,6 +132,7 @@ class VideoDownloadService:
             'extract_flat': True,   # Flat playlist - only get IDs and titles (like --flat-playlist)
             'ignoreerrors': True,
             'match_filter': self._filter_shorts,  # Filter out YouTube Shorts at extraction time
+            'js_runtimes': {},  # Disable JS runtime (fixes yt-dlp >=2025.09.26 validation error)
             # NOTE: Removed extractor_args player_client override
             # yt-dlp 2025.09.26+ automatically selects optimal client
             # Minimal headers to avoid bot detection during light queries

--- a/backend/app/youtube_service.py
+++ b/backend/app/youtube_service.py
@@ -46,7 +46,7 @@ class YouTubeService:
             'quiet': True,
             'no_warnings': True,
             'ignoreerrors': True,
-            'js_runtimes': {},  # Disable JS runtime (fixes yt-dlp >=2025.09.26 validation error)
+            'js_runtimes': {'node': {}},  # Use Node.js runtime (fixes yt-dlp >=2025.09.26 validation error)
             # Anti-bot detection headers - crucial for avoiding 403 errors
             'http_headers': {
                 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',

--- a/backend/app/youtube_service.py
+++ b/backend/app/youtube_service.py
@@ -46,6 +46,7 @@ class YouTubeService:
             'quiet': True,
             'no_warnings': True,
             'ignoreerrors': True,
+            'js_runtimes': {},  # Disable JS runtime (fixes yt-dlp >=2025.09.26 validation error)
             # Anti-bot detection headers - crucial for avoiding 403 errors
             'http_headers': {
                 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',


### PR DESCRIPTION
## Summary
Fixes the "Invalid js_runtimes format, expected a dict of {runtime: {config}}" error that's blocking all video downloads.

## Root Cause
yt-dlp >=2025.09.26 requires the `js_runtimes` parameter to be present as a dictionary. Currently it's undefined, which fails yt-dlp's type validation before any extraction attempts.

## Changes Made
Added `'js_runtimes': {}` to all three yt-dlp configurations:

1. **video_download_service.py:134** - `query_opts` (PRIMARY FIX - where error occurs during video discovery)
2. **video_download_service.py:102** - `download_opts` (preventive, for actual downloads)
3. **youtube_service.py:49** - `base_ydl_opts` (consistency, for channel metadata)

## Technical Details
- Empty dict `{}` tells yt-dlp to disable JS runtime and use fallback extraction methods
- This mirrors TubeSync's proven production pattern
- Minimal, low-risk change - only satisfies validation requirement
- Does not change extraction behavior or YouTube API interactions

## Testing Plan
```bash
# Rebuild and restart backend
docker compose --profile channelfinwatcher up --build -d

# Monitor logs
docker compose --profile channelfinwatcher logs -f

# Trigger manual download via web UI
# Expected: No "Invalid js_runtimes format" errors
# Expected: Video discovery succeeds on Attempt 1
```

## Implementation Strategy
This PR implements **Option 1** (minimal fix). If downloads still fail in production, we have **Option 2** ready: add TubeSync's `extractor_args` pattern with `approximate_date` parameter.

## References
- Previous fix attempt (commit f1006d0) removed invalid `extractor_args` but didn't add `js_runtimes`
- TubeSync reference: Uses `js_runtimes: {}` with `extractor_args: {'youtubetab': {'approximate_date': ['true']}}`
- The previous `{'youtube': {'tab': ['videos']}}` was wrong (wrong extractor name + invalid parameter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)