### PR TITLE
feat: add channel status dashboard with storage monitoring

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -2,10 +2,12 @@
 import os
 import re
 import glob
+import shutil
 import logging
 from datetime import datetime
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -30,6 +32,10 @@ from app.schemas import (
     GlobalDownloadList,
     DownloadHistory as DownloadHistorySchema,
     NfoSettingsUpdate,
+    DiskUsage,
+    ChannelDashboardItem,
+    DashboardTotals,
+    DashboardResponse,
     DownloadTriggerResponse,
     SchedulerStatusResponse,
     UpdateScheduleRequest,
@@ -894,6 +900,115 @@ async def get_channel_downloads(
     return DownloadList(
         downloads=downloads,
         total=total_downloads
+    )
+
+
+STORAGE_WARNING_THRESHOLD_PERCENT = 80.0
+
+
+@router.get("/dashboard", response_model=DashboardResponse)
+async def get_dashboard(db: Session = Depends(get_db)):
+    """
+    Get aggregated channel health and storage data for the status dashboard
+    (US-009: Channel Status Dashboard, US-012: Storage Usage Monitoring).
+
+    Returns, in a single round-trip:
+    - Disk capacity for the volume backing the media directory, with a
+      warning flag at >= 80% usage
+    - System-wide totals (channels, enabled channels, videos, storage)
+    - Per-channel summaries: video count vs limit, storage used, last check
+      time, and the status/error of the most recent download run
+
+    Storage per channel is aggregated from the database (sum of file_size for
+    completed downloads still on disk) rather than walking the filesystem, so
+    the endpoint stays fast regardless of library size.
+
+    Example:
+        GET /api/v1/dashboard
+    """
+    from app.config import get_settings
+    settings = get_settings()
+
+    channels = db.query(Channel).all()
+
+    # Per-channel video count and storage in one aggregate query
+    aggregates = db.query(
+        Download.channel_id,
+        func.count(Download.id).label("video_count"),
+        func.coalesce(func.sum(Download.file_size), 0).label("storage_bytes"),
+    ).filter(
+        Download.status == "completed",
+        Download.file_exists == True  # noqa: E712 (SQLAlchemy expression, not a bool comparison)
+    ).group_by(Download.channel_id).all()
+    stats_by_channel = {row.channel_id: row for row in aggregates}
+
+    # Most recent download run per channel (greatest run_date via self-join)
+    latest_run_subquery = db.query(
+        DownloadHistory.channel_id,
+        func.max(DownloadHistory.run_date).label("max_run_date"),
+    ).group_by(DownloadHistory.channel_id).subquery()
+
+    latest_runs = db.query(DownloadHistory).join(
+        latest_run_subquery,
+        (DownloadHistory.channel_id == latest_run_subquery.c.channel_id)
+        & (DownloadHistory.run_date == latest_run_subquery.c.max_run_date),
+    ).all()
+    run_by_channel = {run.channel_id: run for run in latest_runs}
+
+    items = []
+    total_videos = 0
+    total_storage = 0
+    for channel in channels:
+        stats = stats_by_channel.get(channel.id)
+        video_count = stats.video_count if stats else 0
+        storage_bytes = int(stats.storage_bytes) if stats else 0
+        total_videos += video_count
+        total_storage += storage_bytes
+
+        last_run = run_by_channel.get(channel.id)
+        items.append(ChannelDashboardItem(
+            id=channel.id,
+            name=channel.name,
+            url=channel.url,
+            enabled=channel.enabled,
+            limit=channel.limit,
+            metadata_status=channel.metadata_status,
+            video_count=video_count,
+            storage_bytes=storage_bytes,
+            last_check=channel.last_check,
+            last_run_status=last_run.status if last_run else None,
+            last_run_date=last_run.run_date if last_run else None,
+            last_run_error=last_run.error_message if last_run else None,
+        ))
+
+    # Most recently checked first; never-checked channels last
+    items.sort(key=lambda i: (i.last_check is None, -(i.last_check.timestamp() if i.last_check else 0)))
+
+    # Volume capacity (null rather than 500 if the media dir isn't mounted)
+    disk = None
+    try:
+        usage = shutil.disk_usage(settings.media_dir)
+        usage_percent = (usage.used / usage.total * 100) if usage.total > 0 else 0.0
+        disk = DiskUsage(
+            total_bytes=usage.total,
+            used_bytes=usage.used,
+            free_bytes=usage.free,
+            usage_percent=round(usage_percent, 1),
+            warning=usage_percent >= STORAGE_WARNING_THRESHOLD_PERCENT,
+        )
+    except OSError as e:
+        logger.warning(f"Could not read disk usage for {settings.media_dir}: {e}")
+
+    return DashboardResponse(
+        disk=disk,
+        totals=DashboardTotals(
+            channels=len(channels),
+            enabled_channels=sum(1 for c in channels if c.enabled),
+            videos=total_videos,
+            storage_bytes=total_storage,
+        ),
+        channels=items,
+        generated_at=datetime.utcnow(),
     )
 
 

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -11,6 +11,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.database import get_db
+from app.config import get_settings
 from app.models import Channel, Download, DownloadHistory, ApplicationSettings
 from app.overlap_prevention import scheduler_lock, JobAlreadyRunningError
 from app.youtube_service import youtube_service
@@ -332,8 +333,6 @@ async def reindex_channel(channel_id: int, db: Session = Depends(get_db)):
         HTTPException 404: If channel not found
         HTTPException 409: If another reindex operation is already running
     """
-    from app.config import get_settings
-
     channel = db.query(Channel).filter(Channel.id == channel_id).first()
     if not channel:
         raise HTTPException(status_code=404, detail="Channel not found")
@@ -489,8 +488,6 @@ async def delete_channel(
     Returns:
         dict: Deletion status with media deletion summary
     """
-    from app.config import get_settings
-    
     channel = db.query(Channel).filter(Channel.id == channel_id).first()
     if not channel:
         raise HTTPException(status_code=404, detail="Channel not found")
@@ -926,7 +923,6 @@ async def get_dashboard(db: Session = Depends(get_db)):
     Example:
         GET /api/v1/dashboard
     """
-    from app.config import get_settings
     settings = get_settings()
 
     channels = db.query(Channel).all()
@@ -953,7 +949,12 @@ async def get_dashboard(db: Session = Depends(get_db)):
         (DownloadHistory.channel_id == latest_run_subquery.c.channel_id)
         & (DownloadHistory.run_date == latest_run_subquery.c.max_run_date),
     ).all()
-    run_by_channel = {run.channel_id: run for run in latest_runs}
+    # Tie-break identical run_dates by highest id so the result is deterministic
+    run_by_channel = {}
+    for run in latest_runs:
+        existing = run_by_channel.get(run.channel_id)
+        if existing is None or run.id > existing.id:
+            run_by_channel[run.channel_id] = run
 
     items = []
     total_videos = 0

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -273,6 +273,51 @@ class NfoSettingsUpdate(BaseModel):
     overwrite_existing: Optional[bool] = Field(None, description="Overwrite existing NFO files during regeneration")
 
 
+# Dashboard schemas (US-009/US-012: status dashboard + storage monitoring)
+class DiskUsage(BaseModel):
+    """Disk capacity for the volume backing the media directory."""
+    total_bytes: int = Field(..., description="Total size of the volume")
+    used_bytes: int = Field(..., description="Bytes currently used on the volume")
+    free_bytes: int = Field(..., description="Bytes still available on the volume")
+    usage_percent: float = Field(..., description="Used percentage of the volume (0-100)")
+    warning: bool = Field(..., description="True when usage is at or above the warning threshold (80%)")
+
+
+class ChannelDashboardItem(BaseModel):
+    """Per-channel health and storage summary for the dashboard."""
+    id: int
+    name: str
+    url: str
+    enabled: bool
+    limit: int
+    metadata_status: str
+    video_count: int = Field(0, description="Number of downloaded videos currently on disk")
+    storage_bytes: int = Field(0, description="Total bytes used by this channel's videos")
+    last_check: Optional[datetime] = Field(None, description="Last time the channel was checked (null = never)")
+    last_run_status: Optional[str] = Field(None, description="Status of the most recent download run")
+    last_run_date: Optional[datetime] = Field(None, description="When the most recent download run started")
+    last_run_error: Optional[str] = Field(None, description="Error message from the most recent run, if failed")
+
+    class Config:
+        from_attributes = True
+
+
+class DashboardTotals(BaseModel):
+    """System-wide aggregates for the dashboard header."""
+    channels: int
+    enabled_channels: int
+    videos: int
+    storage_bytes: int
+
+
+class DashboardResponse(BaseModel):
+    """Aggregated payload for the channel status dashboard."""
+    disk: Optional[DiskUsage] = Field(None, description="Volume capacity info (null if media dir unavailable)")
+    totals: DashboardTotals
+    channels: List[ChannelDashboardItem]
+    generated_at: datetime
+
+
 # Error response schemas
 class ErrorDetail(BaseModel):
     """Error detail schema."""

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -298,9 +298,6 @@ class ChannelDashboardItem(BaseModel):
     last_run_date: Optional[datetime] = Field(None, description="When the most recent download run started")
     last_run_error: Optional[str] = Field(None, description="Error message from the most recent run, if failed")
 
-    class Config:
-        from_attributes = True
-
 
 class DashboardTotals(BaseModel):
     """System-wide aggregates for the dashboard header."""

--- a/backend/tests/integration/test_dashboard_api.py
+++ b/backend/tests/integration/test_dashboard_api.py
@@ -1,0 +1,159 @@
+"""Integration tests for the dashboard endpoint (US-009 status dashboard +
+US-012 storage monitoring)."""
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models import Channel, Download, DownloadHistory
+
+
+@pytest.fixture
+def dashboard_fixture(db_session):
+    """Two channels with downloads and run history, one never-checked channel."""
+    now = datetime.utcnow()
+
+    active = Channel(
+        url="https://youtube.com/@active",
+        name="Active Channel",
+        channel_id="UCactiveaaaaaaaaaaaaaa",
+        limit=10,
+        enabled=True,
+        metadata_status="completed",
+        last_check=now - timedelta(hours=1),
+    )
+    failing = Channel(
+        url="https://youtube.com/@failing",
+        name="Failing Channel",
+        channel_id="UCfailingbbbbbbbbbbbbb",
+        limit=5,
+        enabled=True,
+        metadata_status="completed",
+        last_check=now - timedelta(hours=2),
+    )
+    fresh = Channel(
+        url="https://youtube.com/@fresh",
+        name="Fresh Channel",
+        channel_id="UCfreshccccccccccccccc",
+        limit=10,
+        enabled=False,
+        metadata_status="pending",
+        last_check=None,
+    )
+    db_session.add_all([active, failing, fresh])
+    db_session.commit()
+    for channel in (active, failing, fresh):
+        db_session.refresh(channel)
+
+    db_session.add_all([
+        # Two videos on disk for the active channel
+        Download(
+            channel_id=active.id, video_id="vid_active_1", title="Active 1",
+            status="completed", file_exists=True, file_size=1000,
+        ),
+        Download(
+            channel_id=active.id, video_id="vid_active_2", title="Active 2",
+            status="completed", file_exists=True, file_size=2000,
+        ),
+        # Cleaned-up video must not count toward storage or video count
+        Download(
+            channel_id=active.id, video_id="vid_active_gone", title="Active Gone",
+            status="completed", file_exists=False, file_size=4000,
+            deleted_at=now - timedelta(days=1),
+        ),
+        # Failed download must not count either
+        Download(
+            channel_id=failing.id, video_id="vid_fail_1", title="Fail 1",
+            status="failed", error_message="boom", file_exists=False,
+        ),
+        # Run history: an old success and a newer failure for the failing channel
+        DownloadHistory(
+            channel_id=failing.id, run_date=now - timedelta(hours=5),
+            status="completed",
+        ),
+        DownloadHistory(
+            channel_id=failing.id, run_date=now - timedelta(hours=2),
+            status="failed", error_message="Network error during run",
+        ),
+        DownloadHistory(
+            channel_id=active.id, run_date=now - timedelta(hours=1),
+            status="completed",
+        ),
+    ])
+    db_session.commit()
+    return active, failing, fresh
+
+
+class TestDashboardEndpoint:
+    """Tests for GET /api/v1/dashboard."""
+
+    def test_per_channel_video_count_and_storage(self, test_client: TestClient, dashboard_fixture):
+        active, failing, fresh = dashboard_fixture
+
+        response = test_client.get("/api/v1/dashboard")
+
+        assert response.status_code == 200
+        data = response.json()
+        by_id = {c["id"]: c for c in data["channels"]}
+
+        # Only completed downloads still on disk count
+        assert by_id[active.id]["video_count"] == 2
+        assert by_id[active.id]["storage_bytes"] == 3000
+        assert by_id[failing.id]["video_count"] == 0
+        assert by_id[failing.id]["storage_bytes"] == 0
+        assert by_id[fresh.id]["video_count"] == 0
+
+    def test_latest_run_status_per_channel(self, test_client: TestClient, dashboard_fixture):
+        active, failing, fresh = dashboard_fixture
+
+        data = test_client.get("/api/v1/dashboard").json()
+        by_id = {c["id"]: c for c in data["channels"]}
+
+        # The newer failed run wins over the older success
+        assert by_id[failing.id]["last_run_status"] == "failed"
+        assert by_id[failing.id]["last_run_error"] == "Network error during run"
+        assert by_id[active.id]["last_run_status"] == "completed"
+        # Never-run channel has no run info
+        assert by_id[fresh.id]["last_run_status"] is None
+        assert by_id[fresh.id]["last_check"] is None
+
+    def test_totals(self, test_client: TestClient, dashboard_fixture):
+        data = test_client.get("/api/v1/dashboard").json()
+
+        assert data["totals"]["channels"] == 3
+        assert data["totals"]["enabled_channels"] == 2
+        assert data["totals"]["videos"] == 2
+        assert data["totals"]["storage_bytes"] == 3000
+
+    def test_sorted_by_last_check_with_never_checked_last(self, test_client: TestClient, dashboard_fixture):
+        active, failing, fresh = dashboard_fixture
+
+        data = test_client.get("/api/v1/dashboard").json()
+        ids = [c["id"] for c in data["channels"]]
+
+        assert ids == [active.id, failing.id, fresh.id]
+
+    def test_disk_usage_block(self, test_client: TestClient, dashboard_fixture):
+        data = test_client.get("/api/v1/dashboard").json()
+
+        # The test environment's media dir resolves to a real filesystem path,
+        # so the disk block should be present with consistent numbers
+        disk = data["disk"]
+        if disk is not None:
+            assert disk["total_bytes"] > 0
+            assert 0 <= disk["usage_percent"] <= 100
+            assert disk["warning"] == (disk["usage_percent"] >= 80.0)
+
+    def test_empty_database(self, test_client: TestClient):
+        response = test_client.get("/api/v1/dashboard")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["channels"] == []
+        assert data["totals"] == {
+            "channels": 0,
+            "enabled_channels": 0,
+            "videos": 0,
+            "storage_bytes": 0,
+        }
+        assert data["generated_at"] is not None

--- a/frontend/src/__tests__/components/ChannelStatusDashboard.test.tsx
+++ b/frontend/src/__tests__/components/ChannelStatusDashboard.test.tsx
@@ -100,7 +100,8 @@ describe('ChannelStatusDashboard Component', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    // global.fetch is directly assigned (not spied), so restoreAllMocks() won't touch it
+    ;(global.fetch as jest.Mock).mockReset()
   })
 
   it('renders channel cards with video counts and storage', async () => {

--- a/frontend/src/__tests__/components/ChannelStatusDashboard.test.tsx
+++ b/frontend/src/__tests__/components/ChannelStatusDashboard.test.tsx
@@ -1,0 +1,248 @@
+import React from 'react'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ChannelStatusDashboard } from '../../components/ChannelStatusDashboard'
+
+/**
+ * ChannelStatusDashboard Tests (US-009 status dashboard + US-012 storage monitoring)
+ *
+ * Verifies:
+ * - Storage overview, totals, and channel cards render from API data
+ * - Storage warning banner appears at >= 80% usage
+ * - Health indicators (active / disabled / failed / never checked)
+ * - Search filtering and empty states
+ * - Enable/disable quick action calls PUT and refetches
+ */
+
+const GB = 1024 * 1024 * 1024
+
+const baseDashboard = {
+  disk: {
+    total_bytes: 100 * GB,
+    used_bytes: 50 * GB,
+    free_bytes: 50 * GB,
+    usage_percent: 50.0,
+    warning: false,
+  },
+  totals: { channels: 3, enabled_channels: 2, videos: 12, storage_bytes: 9 * GB },
+  channels: [
+    {
+      id: 1,
+      name: 'Active Channel',
+      url: 'https://youtube.com/@active',
+      enabled: true,
+      limit: 10,
+      metadata_status: 'completed',
+      video_count: 8,
+      storage_bytes: 5 * GB,
+      last_check: '2026-06-09T10:00:00',
+      last_run_status: 'completed',
+      last_run_date: '2026-06-09T10:00:00',
+      last_run_error: null,
+    },
+    {
+      id: 2,
+      name: 'Failing Channel',
+      url: 'https://youtube.com/@failing',
+      enabled: true,
+      limit: 5,
+      metadata_status: 'completed',
+      video_count: 4,
+      storage_bytes: 4 * GB,
+      last_check: '2026-06-09T08:00:00',
+      last_run_status: 'failed',
+      last_run_date: '2026-06-09T08:00:00',
+      last_run_error: 'Network error during run',
+    },
+    {
+      id: 3,
+      name: 'Disabled Channel',
+      url: 'https://youtube.com/@disabled',
+      enabled: false,
+      limit: 10,
+      metadata_status: 'pending',
+      video_count: 0,
+      storage_bytes: 0,
+      last_check: null,
+      last_run_status: null,
+      last_run_date: null,
+      last_run_error: null,
+    },
+  ],
+  generated_at: '2026-06-09T12:00:00',
+}
+
+const schedulerStatus = {
+  scheduler_running: true,
+  scheduler_enabled: true,
+  cron_schedule: '0 */6 * * *',
+  next_run: null,
+  last_run: null,
+  download_job_active: true,
+  total_jobs: 1,
+}
+
+function mockFetchImplementation(dashboard = baseDashboard) {
+  return (url: string, options?: RequestInit) => {
+    if (url.startsWith('/api/v1/scheduler/status')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(schedulerStatus) })
+    }
+    if (url.startsWith('/api/v1/channels/') && options?.method === 'PUT') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(dashboard) })
+  }
+}
+
+describe('ChannelStatusDashboard Component', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(mockFetchImplementation()) as jest.Mock
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('renders channel cards with video counts and storage', async () => {
+    render(<ChannelStatusDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Active Channel')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('8/10 videos')).toBeInTheDocument()
+    expect(screen.getByText('5.0 GB')).toBeInTheDocument()
+    expect(screen.getByText('Failing Channel')).toBeInTheDocument()
+    expect(screen.getByText('Disabled Channel')).toBeInTheDocument()
+  })
+
+  it('shows health indicators for each channel state', async () => {
+    render(<ChannelStatusDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Active')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Last run failed')).toBeInTheDocument()
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
+    expect(screen.getByText('Network error during run')).toBeInTheDocument()
+  })
+
+  it('renders the storage overview with capacity', async () => {
+    render(<ChannelStatusDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/50\.0 GB of 100\.0 GB used/)).toBeInTheDocument()
+    })
+
+    // No warning banner below the 80% threshold
+    expect(screen.queryByText(/Storage is .*% full/)).not.toBeInTheDocument()
+  })
+
+  it('shows warning banner when storage is at or above 80%', async () => {
+    const warningDashboard = {
+      ...baseDashboard,
+      disk: {
+        total_bytes: 100 * GB,
+        used_bytes: 85 * GB,
+        free_bytes: 15 * GB,
+        usage_percent: 85.0,
+        warning: true,
+      },
+    }
+    global.fetch = jest.fn(mockFetchImplementation(warningDashboard)) as jest.Mock
+
+    render(<ChannelStatusDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage is 85% full')).toBeInTheDocument()
+    })
+  })
+
+  it('renders library totals', async () => {
+    render(<ChannelStatusDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Channels (2 enabled)')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('9.0 GB')).toBeInTheDocument()
+  })
+
+  it('filters channels by search query', async () => {
+    render(<ChannelStatusDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Active Channel')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText('Search channels'), {
+      target: { value: 'failing' },
+    })
+
+    expect(screen.getByText('Failing Channel')).toBeInTheDocument()
+    expect(screen.queryByText('Active Channel')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Search channels'), {
+      target: { value: 'zzz-no-match' },
+    })
+    expect(screen.getByText('No channels match your search.')).toBeInTheDocument()
+  })
+
+  it('shows empty state with add-channel CTA when there are no channels', async () => {
+    const emptyDashboard = {
+      ...baseDashboard,
+      totals: { channels: 0, enabled_channels: 0, videos: 0, storage_bytes: 0 },
+      channels: [],
+    }
+    global.fetch = jest.fn(mockFetchImplementation(emptyDashboard)) as jest.Mock
+    const onNavigateToChannels = jest.fn()
+
+    render(<ChannelStatusDashboard onNavigateToChannels={onNavigateToChannels} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No channels yet')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /add channel/i }))
+    expect(onNavigateToChannels).toHaveBeenCalledTimes(1)
+  })
+
+  it('toggles channel enabled state via quick action', async () => {
+    render(<ChannelStatusDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Active Channel')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getAllByTitle('Disable monitoring')[0])
+
+    await waitFor(() => {
+      const putCall = (global.fetch as jest.Mock).mock.calls.find(
+        (call) => call[1]?.method === 'PUT'
+      )
+      expect(putCall).toBeDefined()
+      expect(putCall[0]).toBe('/api/v1/channels/1')
+      expect(JSON.parse(putCall[1].body)).toEqual({ enabled: false })
+    })
+  })
+
+  it('shows an error message when the dashboard request fails', async () => {
+    global.fetch = jest.fn((url: string) => {
+      if (url.startsWith('/api/v1/scheduler/status')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(schedulerStatus) })
+      }
+      return Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({ detail: 'Backend unavailable' }),
+      })
+    }) as jest.Mock
+
+    render(<ChannelStatusDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Backend unavailable')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/__tests__/components/DownloadHistory.test.tsx
+++ b/frontend/src/__tests__/components/DownloadHistory.test.tsx
@@ -47,7 +47,7 @@ const mockChannels = [
   { id: 2, name: 'Channel B' },
 ]
 
-function mockFetchImplementation(downloads = mockDownloads, total = downloads.length) {
+function mockFetchImplementation(downloads: object[] = mockDownloads, total = downloads.length) {
   return (url: string) => {
     if (url.startsWith('/api/v1/channels')) {
       return Promise.resolve({

--- a/frontend/src/__tests__/components/Header.test.tsx
+++ b/frontend/src/__tests__/components/Header.test.tsx
@@ -44,8 +44,23 @@ describe('Header Component', () => {
 
     // Verify all navigation options are available
     expect(screen.getByRole('button', { name: /dashboard/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /channels/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /history/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument()
+  })
+
+  it('calls onViewChange with "channels" when channels button is clicked', () => {
+    render(
+      <Header
+        currentView="dashboard"
+        onViewChange={mockOnViewChange}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /channels/i }))
+
+    expect(mockOnViewChange).toHaveBeenCalledWith('channels')
+    expect(mockOnViewChange).toHaveBeenCalledTimes(1)
   })
 
   it('shows dashboard as active when currentView is dashboard', () => {

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react'
 import { Header } from './Header'
+import { ChannelStatusDashboard } from './ChannelStatusDashboard'
 import { YouTubeDownloader } from './YouTubeDownloader'
 import { DownloadHistory } from './DownloadHistory'
 import { Settings } from './Settings'
 
-type ViewType = 'dashboard' | 'history' | 'settings'
+type ViewType = 'dashboard' | 'channels' | 'history' | 'settings'
 
 export function App() {
   const [currentView, setCurrentView] = useState<ViewType>('dashboard')
@@ -21,6 +22,12 @@ export function App() {
       />
       <main className="container mx-auto px-4 py-8">
         {currentView === 'dashboard' && (
+          <ChannelStatusDashboard
+            onNavigateToChannels={() => handleViewChange('channels')}
+            onNavigateToSettings={() => handleViewChange('settings')}
+          />
+        )}
+        {currentView === 'channels' && (
           <YouTubeDownloader onNavigateToSettings={() => handleViewChange('settings')} />
         )}
         {currentView === 'history' && <DownloadHistory />}

--- a/frontend/src/components/ChannelStatusDashboard.tsx
+++ b/frontend/src/components/ChannelStatusDashboard.tsx
@@ -1,0 +1,399 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import {
+  LayoutDashboardIcon,
+  RefreshCwIcon,
+  SearchIcon,
+  HardDriveIcon,
+  YoutubeIcon,
+  AlertTriangleIcon,
+  AlertCircleIcon,
+  CheckCircleIcon,
+  PauseCircleIcon,
+  ClockIcon,
+  VideoIcon,
+  PlusIcon,
+} from 'lucide-react'
+import { SchedulerStatusWidget } from './SchedulerStatusWidget'
+
+/**
+ * ChannelStatusDashboard Component - Landing page with channel health + storage
+ *
+ * Implements User Story 9 (Channel Status Dashboard) and the core of
+ * User Story 12 (Storage Usage Monitoring):
+ * - Storage overview with capacity bar and warning banner at >= 80% usage
+ * - System totals (channels, videos, storage)
+ * - Card grid of all channels: status indicator, video count vs limit,
+ *   storage used, last check time, last run outcome
+ * - Search filter, sort selector, quick enable/disable toggle per card
+ * - Auto-refreshes every 30 seconds
+ *
+ * Technical Details:
+ * - Uses GET /api/v1/dashboard (single aggregated round-trip)
+ * - Enable/disable uses PUT /api/v1/channels/{id} and refetches
+ */
+
+interface DiskUsage {
+  total_bytes: number
+  used_bytes: number
+  free_bytes: number
+  usage_percent: number
+  warning: boolean
+}
+
+interface ChannelSummary {
+  id: number
+  name: string
+  url: string
+  enabled: boolean
+  limit: number
+  metadata_status: string
+  video_count: number
+  storage_bytes: number
+  last_check?: string
+  last_run_status?: string
+  last_run_date?: string
+  last_run_error?: string
+}
+
+interface DashboardData {
+  disk: DiskUsage | null
+  totals: {
+    channels: number
+    enabled_channels: number
+    videos: number
+    storage_bytes: number
+  }
+  channels: ChannelSummary[]
+  generated_at: string
+}
+
+type SortKey = 'recent' | 'storage' | 'name'
+
+const REFRESH_INTERVAL_MS = 30000
+
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes <= 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let size = bytes
+  let unitIndex = 0
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex++
+  }
+  return `${size.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`
+}
+
+function formatRelativeTime(isoDate?: string): string {
+  if (!isoDate) return 'Never'
+  const date = new Date(isoDate.endsWith('Z') ? isoDate : `${isoDate}Z`)
+  if (isNaN(date.getTime())) return 'Never'
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
+  if (seconds < 60) return 'Just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  const days = Math.floor(hours / 24)
+  return `${days} day${days === 1 ? '' : 's'} ago`
+}
+
+/** Health status drives the colored indicator dot and label on each card. */
+function channelHealth(channel: ChannelSummary): { color: string; label: string } {
+  if (!channel.enabled) return { color: 'bg-gray-400', label: 'Disabled' }
+  if (channel.last_run_status === 'failed') return { color: 'bg-red-500', label: 'Last run failed' }
+  if (!channel.last_check) return { color: 'bg-yellow-400', label: 'Never checked' }
+  return { color: 'bg-green-500', label: 'Active' }
+}
+
+function capacityBarColor(percent: number): string {
+  if (percent >= 80) return 'bg-red-500'
+  if (percent >= 70) return 'bg-yellow-500'
+  return 'bg-green-500'
+}
+
+interface ChannelStatusDashboardProps {
+  onNavigateToChannels?: () => void
+  onNavigateToSettings?: () => void
+}
+
+export function ChannelStatusDashboard({
+  onNavigateToChannels,
+  onNavigateToSettings,
+}: ChannelStatusDashboardProps) {
+  const [data, setData] = useState<DashboardData | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [search, setSearch] = useState('')
+  const [sortKey, setSortKey] = useState<SortKey>('recent')
+  const [togglingChannelId, setTogglingChannelId] = useState<number | null>(null)
+
+  const fetchDashboard = useCallback(async (showSpinner = false) => {
+    if (showSpinner) setIsLoading(true)
+    try {
+      const response = await fetch('/api/v1/dashboard')
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}))
+        throw new Error(body.detail || body.error || 'Failed to load dashboard')
+      }
+      setData(await response.json())
+      setError('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load dashboard')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchDashboard(true)
+    const interval = setInterval(() => fetchDashboard(false), REFRESH_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [fetchDashboard])
+
+  const handleToggleEnabled = async (channel: ChannelSummary) => {
+    setTogglingChannelId(channel.id)
+    try {
+      const response = await fetch(`/api/v1/channels/${channel.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: !channel.enabled }),
+      })
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}))
+        throw new Error(body.detail || 'Failed to update channel')
+      }
+      await fetchDashboard(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update channel')
+    } finally {
+      setTogglingChannelId(null)
+    }
+  }
+
+  const visibleChannels = (data?.channels || [])
+    .filter((channel) => {
+      if (!search) return true
+      const query = search.toLowerCase()
+      return channel.name.toLowerCase().includes(query) || channel.url.toLowerCase().includes(query)
+    })
+    .sort((a, b) => {
+      switch (sortKey) {
+        case 'storage':
+          return b.storage_bytes - a.storage_bytes
+        case 'name':
+          return a.name.localeCompare(b.name)
+        default:
+          // API already returns most-recently-checked first
+          return 0
+      }
+    })
+
+  return (
+    <div className="space-y-6 max-w-5xl mx-auto">
+      <SchedulerStatusWidget onNavigateToSettings={onNavigateToSettings} />
+
+      {/* Storage warning banner (US-012: warn at >= 80% capacity) */}
+      {data?.disk?.warning && (
+        <div className="p-4 bg-red-50 border border-red-200 rounded-lg flex items-start">
+          <AlertTriangleIcon className="h-5 w-5 text-red-500 mr-3 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm font-medium text-red-800">
+              Storage is {data.disk.usage_percent}% full
+            </p>
+            <p className="text-sm text-red-700">
+              Only {formatBytes(data.disk.free_bytes)} remaining. Consider lowering video limits
+              on your largest channels below.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Overview row: storage + totals */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="bg-white rounded-lg shadow-md p-5">
+          <div className="flex items-center mb-3">
+            <HardDriveIcon className="h-5 w-5 mr-2 text-gray-500" />
+            <h3 className="font-semibold text-gray-900">Storage</h3>
+          </div>
+          {data?.disk ? (
+            <>
+              <div className="w-full bg-gray-100 rounded-full h-3 mb-2" role="progressbar"
+                aria-valuenow={data.disk.usage_percent} aria-valuemin={0} aria-valuemax={100}>
+                <div
+                  className={`h-3 rounded-full ${capacityBarColor(data.disk.usage_percent)}`}
+                  style={{ width: `${Math.min(100, data.disk.usage_percent)}%` }}
+                />
+              </div>
+              <p className="text-sm text-gray-700">
+                {formatBytes(data.disk.used_bytes)} of {formatBytes(data.disk.total_bytes)} used
+                ({data.disk.usage_percent}%)
+              </p>
+              <p className="text-xs text-gray-500 mt-1">
+                {formatBytes(data.disk.free_bytes)} free &middot; videos use {formatBytes(data.totals.storage_bytes)}
+              </p>
+            </>
+          ) : (
+            <p className="text-sm text-gray-500">Disk information unavailable</p>
+          )}
+        </div>
+
+        <div className="bg-white rounded-lg shadow-md p-5">
+          <div className="flex items-center mb-3">
+            <YoutubeIcon className="h-5 w-5 mr-2 text-gray-500" />
+            <h3 className="font-semibold text-gray-900">Library</h3>
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <div>
+              <p className="text-2xl font-bold text-gray-900">{data?.totals.channels ?? '—'}</p>
+              <p className="text-xs text-gray-500">
+                Channels ({data?.totals.enabled_channels ?? 0} enabled)
+              </p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-gray-900">{data?.totals.videos ?? '—'}</p>
+              <p className="text-xs text-gray-500">Videos</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-gray-900">
+                {data ? formatBytes(data.totals.storage_bytes) : '—'}
+              </p>
+              <p className="text-xs text-gray-500">Video storage</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Channel cards */}
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+          <div className="flex items-center">
+            <LayoutDashboardIcon className="h-6 w-6 mr-2 text-red-600" />
+            <h2 className="text-xl font-semibold text-gray-900">Channel Status</h2>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="relative">
+              <SearchIcon className="h-4 w-4 text-gray-400 absolute left-2.5 top-1/2 -translate-y-1/2" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search channels..."
+                aria-label="Search channels"
+                className="pl-8 pr-3 py-1.5 w-48 rounded-md border border-gray-300 text-sm focus:border-red-500 focus:ring-red-500"
+              />
+            </div>
+            <select
+              value={sortKey}
+              onChange={(e) => setSortKey(e.target.value as SortKey)}
+              aria-label="Sort channels"
+              className="rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-red-500 focus:ring-red-500"
+            >
+              <option value="recent">Recently checked</option>
+              <option value="storage">Largest storage</option>
+              <option value="name">Name</option>
+            </select>
+            <button
+              onClick={() => fetchDashboard(true)}
+              disabled={isLoading}
+              className="inline-flex items-center px-3 py-1.5 rounded-md text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 disabled:opacity-50 transition-colors"
+            >
+              <RefreshCwIcon className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md flex items-start">
+            <AlertCircleIcon className="h-5 w-5 text-red-500 mr-2 flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        )}
+
+        {isLoading && !data ? (
+          <div className="py-12 text-center text-gray-500">
+            <RefreshCwIcon className="h-8 w-8 mx-auto mb-3 animate-spin text-gray-400" />
+            <p>Loading dashboard...</p>
+          </div>
+        ) : visibleChannels.length === 0 ? (
+          <div className="py-12 text-center text-gray-500">
+            <YoutubeIcon className="h-10 w-10 mx-auto mb-3 text-gray-300" />
+            {data && data.channels.length > 0 ? (
+              <p>No channels match your search.</p>
+            ) : (
+              <>
+                <p className="font-medium text-gray-700 mb-1">No channels yet</p>
+                <p className="text-sm mb-4">Add a YouTube channel to start monitoring.</p>
+                {onNavigateToChannels && (
+                  <button
+                    onClick={onNavigateToChannels}
+                    className="inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-white bg-red-600 hover:bg-red-700 transition-colors"
+                  >
+                    <PlusIcon className="h-4 w-4 mr-2" />
+                    Add Channel
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {visibleChannels.map((channel) => {
+              const health = channelHealth(channel)
+              return (
+                <div
+                  key={channel.id}
+                  className={`border rounded-lg p-4 ${channel.enabled ? 'border-gray-200' : 'border-gray-200 bg-gray-50 opacity-75'}`}
+                >
+                  <div className="flex items-start justify-between mb-2">
+                    <div className="min-w-0 mr-2">
+                      <p className="font-medium text-gray-900 truncate" title={channel.name}>
+                        {channel.name || channel.url}
+                      </p>
+                      <p className="flex items-center text-xs text-gray-500 mt-0.5">
+                        <span className={`inline-block h-2 w-2 rounded-full mr-1.5 ${health.color}`} aria-hidden="true" />
+                        {health.label}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => handleToggleEnabled(channel)}
+                      disabled={togglingChannelId === channel.id}
+                      title={channel.enabled ? 'Disable monitoring' : 'Enable monitoring'}
+                      className="text-gray-400 hover:text-gray-600 disabled:opacity-50 flex-shrink-0"
+                    >
+                      {channel.enabled ? (
+                        <PauseCircleIcon className="h-5 w-5" />
+                      ) : (
+                        <CheckCircleIcon className="h-5 w-5" />
+                      )}
+                    </button>
+                  </div>
+
+                  <div className="space-y-1 text-sm text-gray-700">
+                    <p className="flex items-center">
+                      <VideoIcon className="h-4 w-4 mr-1.5 text-gray-400" />
+                      {channel.video_count}/{channel.limit} videos
+                    </p>
+                    <p className="flex items-center">
+                      <HardDriveIcon className="h-4 w-4 mr-1.5 text-gray-400" />
+                      {formatBytes(channel.storage_bytes)}
+                    </p>
+                    <p className="flex items-center">
+                      <ClockIcon className="h-4 w-4 mr-1.5 text-gray-400" />
+                      Checked {formatRelativeTime(channel.last_check)}
+                    </p>
+                  </div>
+
+                  {channel.last_run_status === 'failed' && channel.last_run_error && (
+                    <p className="text-xs text-red-600 mt-2 line-clamp-2" title={channel.last_run_error}>
+                      {channel.last_run_error}
+                    </p>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ChannelStatusDashboard.tsx
+++ b/frontend/src/components/ChannelStatusDashboard.tsx
@@ -295,6 +295,7 @@ export function ChannelStatusDashboard({
             <button
               onClick={() => fetchDashboard(true)}
               disabled={isLoading}
+              aria-label="Refresh dashboard"
               className="inline-flex items-center px-3 py-1.5 rounded-md text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 disabled:opacity-50 transition-colors"
             >
               <RefreshCwIcon className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { YoutubeIcon, Settings as SettingsIcon, HistoryIcon } from 'lucide-react'
+import { YoutubeIcon, Settings as SettingsIcon, HistoryIcon, ListIcon } from 'lucide-react'
 
-type ViewType = 'dashboard' | 'history' | 'settings'
+type ViewType = 'dashboard' | 'channels' | 'history' | 'settings'
 
 interface HeaderProps {
   currentView: ViewType
@@ -28,6 +28,17 @@ export function Header({ currentView, onViewChange }: HeaderProps) {
             }`}
           >
             Dashboard
+          </button>
+          <button
+            onClick={() => onViewChange('channels')}
+            className={`inline-flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+              currentView === 'channels'
+                ? 'bg-red-700 text-white'
+                : 'text-red-100 hover:text-white hover:bg-red-700'
+            }`}
+          >
+            <ListIcon className="h-4 w-4 mr-2" />
+            Channels
           </button>
           <button
             onClick={() => onViewChange('history')}

--- a/frontend/src/pages/api/v1/dashboard.ts
+++ b/frontend/src/pages/api/v1/dashboard.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { fetchBackend, formatApiError } from '@/lib/apiClient'
+
+/**
+ * API route proxy for the channel status dashboard (US-009/US-012).
+ *
+ * Read-only aggregate, so the 'standard' 30s timeout applies.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET'])
+    return res.status(405).json({ error: `Method ${req.method} not allowed` })
+  }
+
+  try {
+    const { status, data } = await fetchBackend('/api/v1/dashboard', {
+      method: 'GET',
+      operationType: 'standard',
+    })
+
+    res.status(status).json(data)
+  } catch (error) {
+    const errorResponse = formatApiError(error, 'Dashboard')
+    res.status(errorResponse.timedOut ? 504 : 500).json(errorResponse)
+  }
+}


### PR DESCRIPTION
## Summary

Implements **US-009 (Channel Status Dashboard)** and the core of **US-012 (Storage Usage Monitoring)** — the two highest-value monitoring gaps from the codebase audit. The dashboard becomes the landing view; the existing add/manage page moves to a new **Channels** nav tab.

### Backend

- New `GET /api/v1/dashboard` endpoint that aggregates everything the dashboard needs in one round-trip:
  - **Disk capacity** for the volume backing the media directory (`shutil.disk_usage`), with a `warning` flag at >= 80% usage. Degrades to `null` instead of erroring if the media dir isn't available.
  - **System totals**: channels, enabled channels, videos, total video storage.
  - **Per-channel summaries**: video count vs limit, storage used, last check time, and the status/error of the most recent download run.
- Per-channel storage and counts come from a single DB aggregation (sum of `file_size` for completed downloads still on disk) rather than walking the filesystem, so the endpoint stays fast regardless of library size. Cleaned-up and failed downloads are excluded.
- Channels are sorted most-recently-checked first, never-checked last.

### Frontend

- New `ChannelStatusDashboard` landing view:
  - Storage capacity bar with green/yellow/red thresholds (70%/80%) and a warning banner at >= 80% with actionable advice
  - Library totals card
  - Responsive channel card grid with health indicators (green active / red last-run-failed / yellow never-checked / gray disabled), `8/10 videos` count vs limit, per-channel storage, relative last-check time, and inline last-run error messages
  - Search filter, sort selector (recently checked / largest storage / name), quick enable/disable toggle per card, empty state with add-channel CTA
  - Auto-refreshes every 30 seconds
- Scheduler status widget now also appears on the dashboard
- Header nav gains a **Channels** tab for the existing management page
- New `/api/v1/dashboard` Next.js proxy route

## Testing

- **Backend:** 289 passed. 6 new integration tests (`test_dashboard_api.py`): per-channel aggregation excludes cleaned-up/failed downloads, latest-run selection picks the newest run per channel, totals, sort order with never-checked channels last, disk block consistency, empty DB.
- **Frontend:** 42 passed. 9 new component tests: card rendering, health indicators, storage overview, 80% warning banner, library totals, search filtering, empty state CTA, enable/disable PUT call, API error state. Header nav coverage extended for the new tab.
- Also fixes a TypeScript type error in the download history test mocks that slipped into #39 (jest doesn't typecheck).
- Pre-existing failures on `main` (8 backend, 20 frontend, 1 TS error in `YouTubeDownloader.tsx`) are unchanged.

https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd)_