### PR TITLE
feat: add per-video retry and honor per-channel schedule overrides

### DIFF
--- a/backend/alembic/versions/b1c2d3e4f5a6_add_retry_count_to_downloads.py
+++ b/backend/alembic/versions/b1c2d3e4f5a6_add_retry_count_to_downloads.py
@@ -1,0 +1,31 @@
+"""add retry_count to downloads
+
+Revision ID: b1c2d3e4f5a6
+Revises: 2obyvozut5uh
+Create Date: 2026-06-10
+
+Adds a retry_count column to the downloads table so automatic re-attempts
+of failed downloads can be bounded (videos that keep failing stop being
+retried after a cap) and surfaced in the UI.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b1c2d3e4f5a6'
+down_revision: Union[str, None] = '2obyvozut5uh'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'downloads',
+        sa.Column('retry_count', sa.Integer(), nullable=False, server_default='0')
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('downloads', 'retry_count')

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -58,6 +58,8 @@ def _normalize_schedule_override(value: Optional[str]) -> Optional[str]:
     Raises:
         HTTPException 400: If the cron expression is invalid
     """
+    # Deferred import: cron_validation resolves the configured timezone at
+    # import time; keeping it lazy avoids ordering surprises at module load
     from app.cron_validation import validate_cron_expression
 
     if value is None or not value.strip():
@@ -80,6 +82,8 @@ def _sync_channel_schedule_safe(channel: Channel):
     scheduler is unavailable (e.g., during tests), log and continue. Jobs
     are also reconciled from the database on every startup.
     """
+    # Deferred import: importing scheduler_service instantiates the global
+    # APScheduler; keep it lazy so importing the API module stays side-effect free
     from app.scheduler_service import scheduler_service
 
     try:
@@ -92,6 +96,8 @@ def _sync_channel_schedule_safe(channel: Channel):
 
 def _remove_channel_schedule_safe(channel_id: int):
     """Remove a deleted channel's per-channel scheduler job, never failing the request."""
+    # Deferred import: importing scheduler_service instantiates the global
+    # APScheduler; keep it lazy so importing the API module stays side-effect free
     from app.scheduler_service import scheduler_service
 
     try:
@@ -1143,9 +1149,13 @@ async def list_all_downloads(
 
 
 @router.post("/downloads/{download_id}/retry", response_model=RetryDownloadResponse)
-async def retry_download(download_id: int, db: Session = Depends(get_db)):
+def retry_download(download_id: int, db: Session = Depends(get_db)):
     """
     Manually retry a failed download.
+
+    Declared sync (not async) on purpose: the download work is blocking
+    (yt-dlp plus retry backoff sleeps), so FastAPI runs this handler in its
+    threadpool instead of stalling the event loop.
 
     Resets the video's retry budget (so a video that exhausted its automatic
     retries becomes eligible again) and immediately attempts the download,
@@ -1199,6 +1209,9 @@ async def retry_download(download_id: int, db: Session = Depends(get_db)):
     download.retry_count = 0
     db.commit()
 
+    # Minimum video_info shape: download_video requires 'id' and 'title';
+    # upload_date/duration_string are read via .get() and backfilled from
+    # .info.json after download
     video_info = {'id': download.video_id, 'title': download.title}
     success, error_message = video_download_service.download_video_with_retry(video_info, channel, db)
 

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -31,6 +31,7 @@ from app.schemas import (
     DownloadList,
     DownloadWithChannel,
     GlobalDownloadList,
+    RetryDownloadResponse,
     DownloadHistory as DownloadHistorySchema,
     NfoSettingsUpdate,
     DiskUsage,
@@ -49,6 +50,54 @@ logger = logging.getLogger(__name__)
 
 # Create API router
 router = APIRouter()
+
+
+def _normalize_schedule_override(value: Optional[str]) -> Optional[str]:
+    """Validate a channel schedule_override, normalizing blank values to None.
+
+    Raises:
+        HTTPException 400: If the cron expression is invalid
+    """
+    from app.cron_validation import validate_cron_expression
+
+    if value is None or not value.strip():
+        return None
+
+    value = value.strip()
+    is_valid, error, _ = validate_cron_expression(value)
+    if not is_valid:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid schedule_override: {error}"
+        )
+    return value
+
+
+def _sync_channel_schedule_safe(channel: Channel):
+    """Sync a channel's per-channel scheduler job, never failing the request.
+
+    Scheduler updates are supplementary to the database change — if the
+    scheduler is unavailable (e.g., during tests), log and continue. Jobs
+    are also reconciled from the database on every startup.
+    """
+    from app.scheduler_service import scheduler_service
+
+    try:
+        scheduler_service.sync_channel_schedule(
+            channel.id, channel.schedule_override, channel.enabled
+        )
+    except Exception as e:
+        logger.warning(f"Failed to sync scheduler job for channel {channel.id}: {e}")
+
+
+def _remove_channel_schedule_safe(channel_id: int):
+    """Remove a deleted channel's per-channel scheduler job, never failing the request."""
+    from app.scheduler_service import scheduler_service
+
+    try:
+        scheduler_service.sync_channel_schedule(channel_id, None, False)
+    except Exception as e:
+        logger.warning(f"Failed to remove scheduler job for channel {channel_id}: {e}")
 
 
 @router.get("/channels", response_model=ChannelList)
@@ -95,6 +144,9 @@ async def create_channel(channel: ChannelCreate, db: Session = Depends(get_db)):
             "quality_preset": "best"
         }
     """
+    # Validate custom schedule before doing any expensive work
+    channel.schedule_override = _normalize_schedule_override(channel.schedule_override)
+
     # Normalize URL to consistent format (handles www, mobile URLs, etc.)
     # This prevents duplicates when users enter different URL formats for same channel
     normalized_url = youtube_service.normalize_channel_url(str(channel.url))
@@ -181,7 +233,11 @@ async def create_channel(channel: ChannelCreate, db: Session = Depends(get_db)):
     except Exception as e:
         logger.warning(f"Failed to sync new channel to YAML: {e}")
         # Don't fail the API call if YAML sync fails
-    
+
+    # Register per-channel scheduler job if a custom schedule was provided (US-016)
+    if db_channel.schedule_override:
+        _sync_channel_schedule_safe(db_channel)
+
     return db_channel
 
 
@@ -239,14 +295,21 @@ async def update_channel(
     channel = db.query(Channel).filter(Channel.id == channel_id).first()
     if not channel:
         raise HTTPException(status_code=404, detail="Channel not found")
-    
+
     # Update only provided fields
     update_data = channel_update.model_dump(exclude_unset=True)
+    if 'schedule_override' in update_data:
+        update_data['schedule_override'] = _normalize_schedule_override(update_data['schedule_override'])
     for field, value in update_data.items():
         setattr(channel, field, value)
-    
+
     db.commit()
     db.refresh(channel)
+
+    # Keep the per-channel scheduler job in sync when the schedule or
+    # enabled state changes (US-016)
+    if 'schedule_override' in update_data or 'enabled' in update_data:
+        _sync_channel_schedule_safe(channel)
     
     # === YAML CONFIGURATION SYNC ===
     # Keep YAML config file in sync with database changes for User Story 2
@@ -539,13 +602,16 @@ async def delete_channel(
     # Delete from database AFTER filesystem operations (cascade deletes Download records)
     db.delete(channel)
     db.commit()
-    
+
     # Remove from YAML config
     try:
         remove_channel_from_yaml(channel_url)
     except Exception as e:
         logger.warning(f"Failed to remove channel from YAML: {e}")
-    
+
+    # Remove any per-channel scheduler job (US-016)
+    _remove_channel_schedule_safe(channel_id)
+
     return {
         "message": f"Channel '{channel_name}' deleted successfully",
         "channel_id": channel_id,
@@ -974,6 +1040,7 @@ async def get_dashboard(db: Session = Depends(get_db)):
             enabled=channel.enabled,
             limit=channel.limit,
             metadata_status=channel.metadata_status,
+            schedule_override=channel.schedule_override,
             video_count=video_count,
             storage_bytes=storage_bytes,
             last_check=channel.last_check,
@@ -1073,6 +1140,74 @@ async def list_all_downloads(
         )
 
     return GlobalDownloadList(downloads=downloads, total=total)
+
+
+@router.post("/downloads/{download_id}/retry", response_model=RetryDownloadResponse)
+async def retry_download(download_id: int, db: Session = Depends(get_db)):
+    """
+    Manually retry a failed download.
+
+    Resets the video's retry budget (so a video that exhausted its automatic
+    retries becomes eligible again) and immediately attempts the download,
+    including within-run retries for transient errors.
+
+    Args:
+        download_id: Database ID of the failed download
+        db: Database session dependency
+
+    Returns:
+        RetryDownloadResponse: Outcome plus the updated download record
+
+    Raises:
+        HTTPException 404: If download not found
+        HTTPException 400: If download is not in failed state or channel is disabled
+        HTTPException 409: If a scheduled download job is currently running
+
+    Example:
+        POST /api/v1/downloads/789/retry
+    """
+    download = db.query(Download).filter(Download.id == download_id).first()
+    if not download:
+        raise HTTPException(status_code=404, detail="Download not found")
+
+    if download.status != 'failed':
+        raise HTTPException(
+            status_code=400,
+            detail=f"Only failed downloads can be retried (current status: {download.status})"
+        )
+
+    channel = db.query(Channel).filter(Channel.id == download.channel_id).first()
+    if not channel:
+        raise HTTPException(status_code=404, detail="Channel for this download no longer exists")
+    if not channel.enabled:
+        raise HTTPException(status_code=400, detail="Channel is disabled")
+
+    # Don't compete with a running scheduled job for the same channel/files
+    running_flag = db.query(ApplicationSettings).filter(
+        ApplicationSettings.key == "scheduled_downloads_running"
+    ).first()
+    if running_flag and running_flag.value == "true":
+        raise HTTPException(
+            status_code=409,
+            detail="A scheduled download job is currently running. Try again when it completes."
+        )
+
+    logger.info(f"Manual retry triggered for download {download_id} ({download.video_id})")
+
+    # Reset the retry budget so the manual attempt (and future automatic
+    # attempts) start fresh
+    download.retry_count = 0
+    db.commit()
+
+    video_info = {'id': download.video_id, 'title': download.title}
+    success, error_message = video_download_service.download_video_with_retry(video_info, channel, db)
+
+    db.refresh(download)
+    return RetryDownloadResponse(
+        success=success,
+        error_message=error_message,
+        download=download,
+    )
 
 
 @router.get("/downloads/{download_id}", response_model=DownloadSchema)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -77,6 +77,7 @@ class Download(Base):
     file_size = Column(Integer, nullable=True)
     status = Column(String, default="pending", index=True)  # pending, downloading, completed, failed
     error_message = Column(Text, nullable=True)
+    retry_count = Column(Integer, default=0, nullable=False)  # Failed run attempts; bounds automatic retries
     file_exists = Column(Boolean, default=True, nullable=False)  # Track if downloaded file exists on disk
     created_at = Column(DateTime, default=datetime.utcnow)
     completed_at = Column(DateTime, nullable=True)

--- a/backend/app/scheduled_download_job.py
+++ b/backend/app/scheduled_download_job.py
@@ -35,8 +35,29 @@ from app.database import SessionLocal
 from app.models import Channel, ApplicationSettings, DownloadHistory, Download
 from app.video_download_service import video_download_service
 from app.overlap_prevention import scheduler_lock, JobAlreadyRunningError
+from app.utils import is_retryable_error
 
 logger = logging.getLogger(__name__)
+
+
+def get_channels_for_global_run(db: Session):
+    """
+    Select the channels the global scheduled job should process.
+
+    Channels with a custom schedule_override are excluded — they are
+    processed by their own per-channel jobs (US-016) instead of the
+    global cron schedule.
+
+    Args:
+        db: Database session
+
+    Returns:
+        List of enabled channels without a custom schedule
+    """
+    return db.query(Channel).filter(
+        Channel.enabled == True,  # noqa: E712 (SQLAlchemy expression)
+        (Channel.schedule_override.is_(None)) | (Channel.schedule_override == '')
+    ).all()
 
 
 async def scheduled_download_job():
@@ -75,8 +96,9 @@ async def scheduled_download_job():
         # Job-level overlap prevention
         with scheduler_lock(db, "scheduled_downloads"):
 
-            # Get all enabled channels
-            channels = db.query(Channel).filter(Channel.enabled == True).all()
+            # Get enabled channels on the global schedule (channels with a
+            # custom schedule_override run via their own per-channel jobs)
+            channels = get_channels_for_global_run(db)
             downloaded_summary["total_channels"] = len(channels)
 
             if not channels:
@@ -175,6 +197,61 @@ async def scheduled_download_job():
         db.close()
 
 
+async def channel_download_job(channel_id: int):
+    """
+    Scheduled job for a single channel with a custom schedule (US-016).
+
+    Created by SchedulerService for each channel whose schedule_override is
+    set. Shares the "scheduled_downloads" lock with the global job, so a
+    per-channel run never overlaps a global run (or another per-channel run)
+    — if the lock is held, this execution is skipped and the channel is
+    picked up at its next scheduled time.
+
+    Args:
+        channel_id: Database ID of the channel to process
+    """
+    db = SessionLocal()
+    try:
+        channel = db.query(Channel).filter(Channel.id == channel_id).first()
+        if not channel:
+            logger.warning(f"Per-channel job: channel {channel_id} no longer exists, skipping")
+            return
+        if not channel.enabled:
+            logger.info(f"Per-channel job: channel '{channel.name}' is disabled, skipping")
+            return
+
+        logger.info(f"Starting per-channel scheduled download for '{channel.name}' (ID: {channel_id})")
+
+        with scheduler_lock(db, "scheduled_downloads"):
+            success, videos_downloaded, error_message = await _process_channel_with_recovery(channel, db)
+
+            if success:
+                try:
+                    deleted_count = await cleanup_old_videos(channel, db)
+                    if deleted_count > 0:
+                        logger.info(
+                            f"Cleaned up {deleted_count} old video(s) for channel '{channel.name}' "
+                            f"(limit: {channel.limit})"
+                        )
+                except Exception as e:
+                    logger.error(f"Cleanup failed for channel '{channel.name}': {e}")
+
+                logger.info(
+                    f"Per-channel job for '{channel.name}' completed: {videos_downloaded} videos downloaded"
+                )
+            else:
+                logger.error(f"Per-channel job for '{channel.name}' failed: {error_message}")
+
+    except JobAlreadyRunningError:
+        logger.info(
+            f"Per-channel job for channel {channel_id} skipped - another download job is running"
+        )
+    except Exception as e:
+        logger.error(f"Critical error in per-channel job for channel {channel_id}: {e}")
+    finally:
+        db.close()
+
+
 async def _process_channel_with_recovery(channel: Channel, db: Session) -> Tuple[bool, int, str]:
     """
     Process single channel with comprehensive error recovery.
@@ -254,18 +331,9 @@ def _is_retryable_error(error_message: str) -> bool:
     Returns:
         True if error should be retried, False otherwise
     """
-    if not error_message:
-        return False
-
-    # Network-related errors are retryable
-    retryable_keywords = [
-        "network", "timeout", "connection", "temporary",
-        "rate limit", "quota", "503", "502", "504",
-        "429"  # Too Many Requests
-    ]
-
-    error_lower = error_message.lower()
-    return any(keyword in error_lower for keyword in retryable_keywords)
+    # Delegates to the shared classifier so channel-level and per-video
+    # retry logic agree on what counts as transient
+    return is_retryable_error(error_message)
 
 
 def _create_failed_history_record(channel_id: int, error_message: str, db: Session):

--- a/backend/app/scheduled_download_job.py
+++ b/backend/app/scheduled_download_job.py
@@ -248,6 +248,9 @@ async def channel_download_job(channel_id: int):
         )
     except Exception as e:
         logger.error(f"Critical error in per-channel job for channel {channel_id}: {e}")
+        # Record the failure so it's visible in the Download History view,
+        # matching the global job's behavior for unexpected errors
+        _create_failed_history_record(channel_id, str(e), db)
     finally:
         db.close()
 

--- a/backend/app/scheduler_service.py
+++ b/backend/app/scheduler_service.py
@@ -135,6 +135,9 @@ class SchedulerService:
             # Load and configure cron schedule from database
             await self._load_cron_schedule()
 
+            # Reconcile per-channel schedule overrides (US-016)
+            self.sync_all_channel_schedules()
+
             # Log recovered jobs
             jobs = self.scheduler.get_jobs()
             if jobs:
@@ -232,6 +235,86 @@ class SchedulerService:
         except Exception as e:
             logger.error(f"Failed to update download schedule: {e}")
             raise
+
+    CHANNEL_JOB_PREFIX = 'channel_download_job_'
+
+    def sync_channel_schedule(self, channel_id: int, cron_expression: Optional[str], enabled: bool):
+        """Create, update, or remove the per-channel download job (US-016).
+
+        Channels with a schedule_override run on their own cron job instead
+        of the global schedule. This method keeps the APScheduler job in sync
+        with the channel's current configuration.
+
+        Args:
+            channel_id: Database ID of the channel
+            cron_expression: The channel's schedule_override (None/empty removes the job)
+            enabled: Whether the channel is enabled (disabled channels get no job)
+
+        Raises:
+            ValueError: If cron_expression is invalid (callers should validate first)
+        """
+        from app.scheduled_download_job import channel_download_job
+
+        job_id = f"{self.CHANNEL_JOB_PREFIX}{channel_id}"
+
+        if not cron_expression or not enabled:
+            if self.scheduler.get_job(job_id):
+                self.scheduler.remove_job(job_id)
+                logger.info(f"Removed per-channel schedule job for channel {channel_id}")
+            return
+
+        trigger = CronTrigger.from_crontab(cron_expression, timezone=settings.scheduler_timezone)
+        self.scheduler.add_job(
+            func=channel_download_job,
+            trigger=trigger,
+            args=[channel_id],
+            id=job_id,
+            name=f'Channel {channel_id} Downloads',
+            replace_existing=True
+        )
+        logger.info(f"Scheduled per-channel downloads for channel {channel_id}: {cron_expression}")
+
+    def sync_all_channel_schedules(self):
+        """Reconcile all per-channel jobs with the database on startup.
+
+        Ensures every enabled channel with a valid schedule_override has a
+        job, and removes persisted jobs for channels that were deleted,
+        disabled, or reverted to the global schedule while the app was down.
+        """
+        from app.models import Channel
+
+        db = SessionLocal()
+        try:
+            channels = db.query(Channel).all()
+            expected_jobs = {}
+            for channel in channels:
+                if channel.enabled and channel.schedule_override:
+                    expected_jobs[f"{self.CHANNEL_JOB_PREFIX}{channel.id}"] = channel
+
+            # Remove stale per-channel jobs (channel deleted/disabled/reverted)
+            for job in self.scheduler.get_jobs():
+                if job.id.startswith(self.CHANNEL_JOB_PREFIX) and job.id not in expected_jobs:
+                    self.scheduler.remove_job(job.id)
+                    logger.info(f"Removed stale per-channel job: {job.id}")
+
+            # Create/update jobs for current overrides
+            for job_id, channel in expected_jobs.items():
+                try:
+                    self.sync_channel_schedule(channel.id, channel.schedule_override, channel.enabled)
+                except Exception as e:
+                    # An invalid persisted override shouldn't block startup
+                    logger.error(
+                        f"Skipping invalid schedule_override for channel '{channel.name}' "
+                        f"({channel.schedule_override!r}): {e}"
+                    )
+
+            if expected_jobs:
+                logger.info(f"Synced {len(expected_jobs)} per-channel schedule(s)")
+
+        except Exception as e:
+            logger.error(f"Failed to sync per-channel schedules: {e}")
+        finally:
+            db.close()
 
     def get_schedule_status(self) -> Dict:
         """Get current schedule status for monitoring.

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -80,6 +80,7 @@ class Download(DownloadBase):
     file_size: Optional[int] = Field(None, description="File size in bytes")
     status: str = Field(..., description="Download status")
     error_message: Optional[str] = Field(None, description="Error message if failed")
+    retry_count: int = Field(0, description="Number of failed run attempts for this video")
     created_at: datetime = Field(..., description="When download was created")
     completed_at: Optional[datetime] = Field(None, description="When download completed")
 
@@ -168,6 +169,13 @@ class GlobalDownloadList(BaseModel):
     """Schema for the global (cross-channel) download history view."""
     downloads: List[DownloadWithChannel]
     total: int = Field(..., description="Total number of downloads matching the filters")
+
+
+class RetryDownloadResponse(BaseModel):
+    """Response for manually retrying a failed download."""
+    success: bool = Field(..., description="Whether the retry succeeded")
+    error_message: Optional[str] = Field(None, description="Error message if the retry failed")
+    download: Download = Field(..., description="The download record after the retry attempt")
 
 
 class DownloadTriggerResponse(BaseModel):
@@ -291,6 +299,7 @@ class ChannelDashboardItem(BaseModel):
     enabled: bool
     limit: int
     metadata_status: str
+    schedule_override: Optional[str] = Field(None, description="Custom cron schedule (null = global schedule)")
     video_count: int = Field(0, description="Number of downloaded videos currently on disk")
     storage_bytes: int = Field(0, description="Total bytes used by this channel's videos")
     last_check: Optional[datetime] = Field(None, description="Last time the channel was checked (null = never)")

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -543,3 +543,34 @@ def sync_all_settings_to_yaml(db_session) -> bool:
     except Exception as e:
         logger.error(f"Failed to sync all settings to YAML: {e}")
         return False
+
+
+def is_retryable_error(error_message: str) -> bool:
+    """
+    Determine if a download error is transient and worth retrying.
+
+    Shared by channel-level retry (scheduled_download_job) and per-video
+    retry (video_download_service) so both layers agree on what counts
+    as transient.
+
+    Retryable: network timeouts, connection issues, rate limiting,
+    temporary service unavailability.
+    Non-retryable: deleted/private videos, invalid URLs, auth failures.
+
+    Args:
+        error_message: Error message string from a failed operation
+
+    Returns:
+        True if the error should be retried, False otherwise
+    """
+    if not error_message:
+        return False
+
+    retryable_keywords = [
+        "network", "timeout", "connection", "temporary",
+        "rate limit", "quota", "503", "502", "504",
+        "429"  # Too Many Requests
+    ]
+
+    error_lower = error_message.lower()
+    return any(keyword in error_lower for keyword in retryable_keywords)

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -11,7 +11,7 @@ import yt_dlp
 
 from app.models import Channel, Download, DownloadHistory
 from app.config import get_settings
-from app.utils import channel_dir_name
+from app.utils import channel_dir_name, is_retryable_error
 from app.nfo_service import get_nfo_service
 
 logger = logging.getLogger(__name__)
@@ -43,6 +43,16 @@ class VideoDownloadService:
     # Recognized video file extensions
     # Used for file detection, verification, and .info.json path derivation
     VIDEO_EXTENSIONS = ('.mkv', '.mp4', '.webm', '.avi', '.mov', '.flv', '.m4v', '.3gp')
+
+    # Per-video retry policy:
+    # - Within a run: retry transient failures up to WITHIN_RUN_RETRIES extra
+    #   times with a short backoff (handles brief network hiccups)
+    # - Across runs: stop auto-attempting a failed video once retry_count
+    #   reaches MAX_AUTO_RETRIES (prevents hammering permanently broken videos
+    #   on every run; a manual retry resets the counter)
+    WITHIN_RUN_RETRIES = 2
+    RETRY_BACKOFF_SECONDS = 10
+    MAX_AUTO_RETRIES = 5
 
     def __init__(self):
         """
@@ -251,6 +261,14 @@ class VideoDownloadService:
         if download:
             if download.status == 'completed' and download.file_exists:
                 return False, download  # Skip - already have it
+            elif download.status == 'failed' and (download.retry_count or 0) >= self.MAX_AUTO_RETRIES:
+                # Permanently failing video - stop auto-retrying it every run.
+                # A manual retry (which resets retry_count) can revive it.
+                logger.debug(
+                    f"Skipping video {video_id}: failed {download.retry_count} times "
+                    f"(max auto-retries: {self.MAX_AUTO_RETRIES})"
+                )
+                return False, download
             elif not download.file_exists:
                 return True, download   # Re-download missing file
         
@@ -910,6 +928,55 @@ class VideoDownloadService:
         logger.error("All extraction attempts failed")
         return False, [], "Could not extract videos using any method"
     
+    def download_video_with_retry(self, video_info: Dict, channel: Channel, db: Session) -> Tuple[bool, Optional[str]]:
+        """
+        Download a single video, retrying transient failures within the run.
+
+        Wraps download_video with the per-video retry policy:
+        - Up to WITHIN_RUN_RETRIES extra attempts for retryable errors
+          (network/timeout/rate-limit), with a short backoff between attempts
+        - On success: resets the record's retry_count so future failures
+          start a fresh budget
+        - On final failure: increments retry_count (once per run, not per
+          attempt) so should_download_video can stop auto-retrying the video
+          after MAX_AUTO_RETRIES failed runs
+
+        Args:
+            video_info: Dictionary containing video metadata
+            channel: Channel database model
+            db: Database session
+
+        Returns:
+            Tuple of (success, error_message)
+        """
+        video_id = video_info['id']
+        attempts = 1 + self.WITHIN_RUN_RETRIES
+
+        success, error = False, None
+        for attempt in range(1, attempts + 1):
+            success, error = self.download_video(video_info, channel, db)
+
+            if success or not is_retryable_error(error):
+                break
+
+            if attempt < attempts:
+                logger.warning(
+                    f"Transient failure for video {video_id} "
+                    f"(attempt {attempt}/{attempts}), retrying in {self.RETRY_BACKOFF_SECONDS}s: {error}"
+                )
+                time.sleep(self.RETRY_BACKOFF_SECONDS)
+
+        # Update the retry budget on the download record
+        download = db.query(Download).filter(
+            Download.video_id == video_id,
+            Download.channel_id == channel.id
+        ).first()
+        if download:
+            download.retry_count = 0 if success else (download.retry_count or 0) + 1
+            db.commit()
+
+        return success, error
+
     def download_video(self, video_info: Dict, channel: Channel, db: Session) -> Tuple[bool, Optional[str]]:
         """
         Download a single video with status tracking.
@@ -1205,9 +1272,9 @@ class VideoDownloadService:
             for idx, video_info in enumerate(new_videos, 1):
                 video_title_short = video_info['title'][:50] + '...' if len(video_info['title']) > 50 else video_info['title']
 
-                # Download the video
+                # Download the video (with within-run retry for transient errors)
                 logger.info(f"  ⬇️  Video {idx}/{len(new_videos)}: DOWNLOADING - {video_title_short}")
-                download_success, download_error = self.download_video(video_info, channel, db)
+                download_success, download_error = self.download_video_with_retry(video_info, channel, db)
 
                 if download_success:
                     downloaded_count += 1

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -261,7 +261,7 @@ class VideoDownloadService:
         if download:
             if download.status == 'completed' and download.file_exists:
                 return False, download  # Skip - already have it
-            elif download.status == 'failed' and (download.retry_count or 0) >= self.MAX_AUTO_RETRIES:
+            elif download.status == 'failed' and download.retry_count >= self.MAX_AUTO_RETRIES:
                 # Permanently failing video - stop auto-retrying it every run.
                 # A manual retry (which resets retry_count) can revive it.
                 logger.debug(
@@ -972,7 +972,7 @@ class VideoDownloadService:
             Download.channel_id == channel.id
         ).first()
         if download:
-            download.retry_count = 0 if success else (download.retry_count or 0) + 1
+            download.retry_count = 0 if success else download.retry_count + 1
             db.commit()
 
         return success, error

--- a/backend/tests/integration/test_retry_and_schedules.py
+++ b/backend/tests/integration/test_retry_and_schedules.py
@@ -1,0 +1,332 @@
+"""Tests for per-video retry (manual + automatic) and per-channel schedule
+overrides (US-013 manual control, US-016 schedule configuration)."""
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import Channel, Download, ApplicationSettings
+from app.scheduled_download_job import get_channels_for_global_run
+from app.video_download_service import VideoDownloadService, video_download_service
+
+
+@pytest.fixture
+def channel_with_failed_download(db_session):
+    channel = Channel(
+        url="https://youtube.com/@retrychannel",
+        name="Retry Channel",
+        channel_id="UCretryaaaaaaaaaaaaaaa",
+        limit=10,
+        enabled=True,
+        metadata_status="completed",
+    )
+    db_session.add(channel)
+    db_session.commit()
+    db_session.refresh(channel)
+
+    download = Download(
+        channel_id=channel.id,
+        video_id="vid_failed_1",
+        title="Failed Video",
+        status="failed",
+        error_message="Network error",
+        retry_count=5,
+        file_exists=False,
+    )
+    db_session.add(download)
+    db_session.commit()
+    db_session.refresh(download)
+    return channel, download
+
+
+class TestRetryEndpoint:
+    """Tests for POST /api/v1/downloads/{id}/retry."""
+
+    def test_retry_not_found(self, test_client: TestClient):
+        response = test_client.post("/api/v1/downloads/9999/retry")
+        assert response.status_code == 404
+
+    def test_retry_rejects_non_failed_download(
+        self, test_client: TestClient, db_session: Session, channel_with_failed_download
+    ):
+        channel, download = channel_with_failed_download
+        download.status = "completed"
+        db_session.commit()
+
+        response = test_client.post(f"/api/v1/downloads/{download.id}/retry")
+
+        assert response.status_code == 400
+        assert "Only failed downloads" in response.json()["detail"]
+
+    def test_retry_rejects_disabled_channel(
+        self, test_client: TestClient, db_session: Session, channel_with_failed_download
+    ):
+        channel, download = channel_with_failed_download
+        channel.enabled = False
+        db_session.commit()
+
+        response = test_client.post(f"/api/v1/downloads/{download.id}/retry")
+
+        assert response.status_code == 400
+        assert "disabled" in response.json()["detail"]
+
+    def test_retry_returns_409_while_scheduler_runs(
+        self, test_client: TestClient, db_session: Session, channel_with_failed_download
+    ):
+        channel, download = channel_with_failed_download
+        db_session.add(ApplicationSettings(key="scheduled_downloads_running", value="true"))
+        db_session.commit()
+
+        response = test_client.post(f"/api/v1/downloads/{download.id}/retry")
+
+        assert response.status_code == 409
+
+    def test_retry_resets_budget_and_attempts_download(
+        self, test_client: TestClient, db_session: Session, channel_with_failed_download
+    ):
+        channel, download = channel_with_failed_download
+
+        def fake_retry(video_info, ch, db):
+            # Simulate what a successful download does to the record
+            record = db.query(Download).filter(Download.id == download.id).first()
+            record.status = "completed"
+            record.file_exists = True
+            db.commit()
+            return True, None
+
+        with patch.object(video_download_service, "download_video_with_retry", side_effect=fake_retry) as mock_retry:
+            response = test_client.post(f"/api/v1/downloads/{download.id}/retry")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["download"]["status"] == "completed"
+        mock_retry.assert_called_once()
+        # video_info passed through with the stored id/title
+        video_info = mock_retry.call_args[0][0]
+        assert video_info == {"id": "vid_failed_1", "title": "Failed Video"}
+
+        db_session.refresh(download)
+        assert download.retry_count == 0  # Budget reset before the attempt
+
+
+class TestAutomaticRetryPolicy:
+    """Tests for within-run retry and the cross-run auto-retry cap."""
+
+    def test_should_download_skips_video_over_retry_cap(
+        self, db_session: Session, channel_with_failed_download
+    ):
+        channel, download = channel_with_failed_download
+        download.retry_count = VideoDownloadService.MAX_AUTO_RETRIES
+        db_session.commit()
+
+        should, record = video_download_service.should_download_video(
+            download.video_id, channel, db_session
+        )
+
+        assert should is False
+        assert record.id == download.id
+
+    def test_should_download_allows_video_under_retry_cap(
+        self, db_session: Session, channel_with_failed_download
+    ):
+        channel, download = channel_with_failed_download
+        download.retry_count = VideoDownloadService.MAX_AUTO_RETRIES - 1
+        db_session.commit()
+
+        should, _ = video_download_service.should_download_video(
+            download.video_id, channel, db_session
+        )
+
+        assert should is True
+
+    def test_within_run_retry_on_transient_error(
+        self, db_session: Session, channel_with_failed_download
+    ):
+        channel, download = channel_with_failed_download
+        download.retry_count = 0
+        db_session.commit()
+        video_info = {"id": download.video_id, "title": download.title}
+
+        with patch.object(video_download_service, "download_video", return_value=(False, "Connection timeout")) as mock_dl, \
+                patch("app.video_download_service.time.sleep") as mock_sleep:
+            success, error = video_download_service.download_video_with_retry(video_info, channel, db_session)
+
+        assert success is False
+        # Initial attempt + WITHIN_RUN_RETRIES extra attempts
+        assert mock_dl.call_count == 1 + VideoDownloadService.WITHIN_RUN_RETRIES
+        assert mock_sleep.call_count == VideoDownloadService.WITHIN_RUN_RETRIES
+        # One failed run = +1 on the budget (not one per attempt)
+        db_session.refresh(download)
+        assert download.retry_count == 1
+
+    def test_no_retry_on_permanent_error(
+        self, db_session: Session, channel_with_failed_download
+    ):
+        channel, download = channel_with_failed_download
+        video_info = {"id": download.video_id, "title": download.title}
+
+        with patch.object(video_download_service, "download_video", return_value=(False, "Video unavailable: private")) as mock_dl, \
+                patch("app.video_download_service.time.sleep") as mock_sleep:
+            success, _ = video_download_service.download_video_with_retry(video_info, channel, db_session)
+
+        assert success is False
+        mock_dl.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    def test_success_resets_retry_budget(
+        self, db_session: Session, channel_with_failed_download
+    ):
+        channel, download = channel_with_failed_download
+        download.retry_count = 3
+        db_session.commit()
+        video_info = {"id": download.video_id, "title": download.title}
+
+        with patch.object(video_download_service, "download_video", return_value=(True, None)):
+            success, _ = video_download_service.download_video_with_retry(video_info, channel, db_session)
+
+        assert success is True
+        db_session.refresh(download)
+        assert download.retry_count == 0
+
+
+class TestGlobalRunChannelSelection:
+    """Channels with a schedule_override must be excluded from the global run."""
+
+    def test_excludes_channels_with_override(self, db_session: Session):
+        on_global = Channel(
+            url="https://youtube.com/@global", name="Global", channel_id="UCglobal111111111111",
+            enabled=True,
+        )
+        blank_override = Channel(
+            url="https://youtube.com/@blank", name="Blank", channel_id="UCblank2222222222222",
+            enabled=True, schedule_override="",
+        )
+        custom = Channel(
+            url="https://youtube.com/@custom", name="Custom", channel_id="UCcustom333333333333",
+            enabled=True, schedule_override="0 */2 * * *",
+        )
+        disabled = Channel(
+            url="https://youtube.com/@off", name="Off", channel_id="UCoff444444444444444",
+            enabled=False,
+        )
+        db_session.add_all([on_global, blank_override, custom, disabled])
+        db_session.commit()
+
+        names = {c.name for c in get_channels_for_global_run(db_session)}
+
+        # Blank override means "use global schedule"; disabled and custom excluded
+        assert names == {"Global", "Blank"}
+
+
+class TestScheduleOverrideValidation:
+    """Validation and scheduler sync when setting schedule_override via the API."""
+
+    @pytest.fixture
+    def channel(self, db_session):
+        channel = Channel(
+            url="https://youtube.com/@schedchannel",
+            name="Sched Channel",
+            channel_id="UCschedaaaaaaaaaaaaaa",
+            limit=10,
+            enabled=True,
+            metadata_status="completed",
+        )
+        db_session.add(channel)
+        db_session.commit()
+        db_session.refresh(channel)
+        return channel
+
+    def test_rejects_invalid_cron(self, test_client: TestClient, channel):
+        response = test_client.put(
+            f"/api/v1/channels/{channel.id}",
+            json={"schedule_override": "not a cron"},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid schedule_override" in response.json()["detail"]
+
+    def test_rejects_every_minute_schedule(self, test_client: TestClient, channel):
+        response = test_client.put(
+            f"/api/v1/channels/{channel.id}",
+            json={"schedule_override": "* * * * *"},
+        )
+
+        assert response.status_code == 400
+
+    def test_accepts_valid_cron_and_syncs_job(self, test_client: TestClient, db_session, channel):
+        with patch("app.scheduler_service.scheduler_service") as mock_service:
+            response = test_client.put(
+                f"/api/v1/channels/{channel.id}",
+                json={"schedule_override": "0 */2 * * *"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["schedule_override"] == "0 */2 * * *"
+        db_session.refresh(channel)
+        assert channel.schedule_override == "0 */2 * * *"
+        mock_service.sync_channel_schedule.assert_called_once_with(
+            channel.id, "0 */2 * * *", True
+        )
+
+    def test_blank_override_normalizes_to_none(self, test_client: TestClient, db_session, channel):
+        channel.schedule_override = "0 */2 * * *"
+        db_session.commit()
+
+        with patch("app.scheduler_service.scheduler_service") as mock_service:
+            response = test_client.put(
+                f"/api/v1/channels/{channel.id}",
+                json={"schedule_override": "   "},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["schedule_override"] is None
+        mock_service.sync_channel_schedule.assert_called_once_with(channel.id, None, True)
+
+
+class TestSchedulerServiceChannelJobs:
+    """Unit tests for per-channel job management in SchedulerService."""
+
+    def _service_with_mock_scheduler(self):
+        from app.scheduler_service import SchedulerService
+
+        service = SchedulerService.__new__(SchedulerService)  # Skip real APScheduler setup
+        service.scheduler = MagicMock()
+        return service
+
+    def test_adds_job_for_valid_override(self):
+        service = self._service_with_mock_scheduler()
+
+        service.sync_channel_schedule(42, "0 */2 * * *", enabled=True)
+
+        service.scheduler.add_job.assert_called_once()
+        kwargs = service.scheduler.add_job.call_args[1]
+        assert kwargs["id"] == "channel_download_job_42"
+        assert kwargs["args"] == [42]
+        assert kwargs["replace_existing"] is True
+
+    def test_removes_job_when_override_cleared(self):
+        service = self._service_with_mock_scheduler()
+        service.scheduler.get_job.return_value = MagicMock()
+
+        service.sync_channel_schedule(42, None, enabled=True)
+
+        service.scheduler.remove_job.assert_called_once_with("channel_download_job_42")
+        service.scheduler.add_job.assert_not_called()
+
+    def test_removes_job_when_channel_disabled(self):
+        service = self._service_with_mock_scheduler()
+        service.scheduler.get_job.return_value = MagicMock()
+
+        service.sync_channel_schedule(42, "0 */2 * * *", enabled=False)
+
+        service.scheduler.remove_job.assert_called_once_with("channel_download_job_42")
+        service.scheduler.add_job.assert_not_called()
+
+    def test_invalid_cron_raises(self):
+        service = self._service_with_mock_scheduler()
+
+        with pytest.raises(ValueError):
+            service.sync_channel_schedule(42, "totally invalid", enabled=True)

--- a/frontend/src/__tests__/components/ChannelStatusDashboard.test.tsx
+++ b/frontend/src/__tests__/components/ChannelStatusDashboard.test.tsx
@@ -129,6 +129,23 @@ describe('ChannelStatusDashboard Component', () => {
     expect(screen.getByText('Network error during run')).toBeInTheDocument()
   })
 
+  it('shows custom schedule indicator for channels with an override', async () => {
+    const withOverride = {
+      ...baseDashboard,
+      channels: [
+        { ...baseDashboard.channels[0], schedule_override: '0 */2 * * *' },
+        ...baseDashboard.channels.slice(1),
+      ],
+    }
+    global.fetch = jest.fn(mockFetchImplementation(withOverride)) as jest.Mock
+
+    render(<ChannelStatusDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Custom schedule: 0 */2 * * *')).toBeInTheDocument()
+    })
+  })
+
   it('renders the storage overview with capacity', async () => {
     render(<ChannelStatusDashboard />)
 

--- a/frontend/src/__tests__/components/DownloadHistory.test.tsx
+++ b/frontend/src/__tests__/components/DownloadHistory.test.tsx
@@ -48,11 +48,17 @@ const mockChannels = [
 ]
 
 function mockFetchImplementation(downloads: object[] = mockDownloads, total = downloads.length) {
-  return (url: string) => {
+  return (url: string, options?: RequestInit) => {
     if (url.startsWith('/api/v1/channels')) {
       return Promise.resolve({
         ok: true,
         json: () => Promise.resolve({ channels: mockChannels, total: 2, enabled: 2 }),
+      })
+    }
+    if (url.includes('/retry') && options?.method === 'POST') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ success: true, error_message: null, download: {} }),
       })
     }
     return Promise.resolve({
@@ -113,6 +119,62 @@ describe('DownloadHistory Component', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Network error during download')).toBeInTheDocument()
+    })
+  })
+
+  it('shows a Retry button only on failed downloads and triggers the retry', async () => {
+    render(<DownloadHistory />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Second Video')).toBeInTheDocument()
+    })
+
+    // Only the failed download (id=2) gets a Retry button
+    const retryButtons = screen.getAllByRole('button', { name: /retry/i })
+    expect(retryButtons).toHaveLength(1)
+
+    fireEvent.click(retryButtons[0])
+
+    await waitFor(() => {
+      const retryCall = (global.fetch as jest.Mock).mock.calls.find(
+        (call) => String(call[0]).includes('/retry')
+      )
+      expect(retryCall).toBeDefined()
+      expect(retryCall[0]).toBe('/api/v1/downloads/2/retry')
+      expect(retryCall[1]?.method).toBe('POST')
+    })
+  })
+
+  it('surfaces an error when the retry fails again', async () => {
+    global.fetch = jest.fn((url: string, options?: RequestInit) => {
+      if (url.startsWith('/api/v1/channels')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ channels: mockChannels, total: 2, enabled: 2 }),
+        })
+      }
+      if (url.includes('/retry') && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ success: false, error_message: 'Still unavailable', download: {} }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ downloads: mockDownloads, total: 2 }),
+      })
+    }) as jest.Mock
+
+    render(<DownloadHistory />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Second Video')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Retry of "Second Video" failed: Still unavailable/)).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/ChannelStatusDashboard.tsx
+++ b/frontend/src/components/ChannelStatusDashboard.tsx
@@ -12,6 +12,7 @@ import {
   ClockIcon,
   VideoIcon,
   PlusIcon,
+  CalendarClockIcon,
 } from 'lucide-react'
 import { SchedulerStatusWidget } from './SchedulerStatusWidget'
 
@@ -47,6 +48,7 @@ interface ChannelSummary {
   enabled: boolean
   limit: number
   metadata_status: string
+  schedule_override?: string
   video_count: number
   storage_bytes: number
   last_check?: string
@@ -382,6 +384,12 @@ export function ChannelStatusDashboard({
                       <ClockIcon className="h-4 w-4 mr-1.5 text-gray-400" />
                       Checked {formatRelativeTime(channel.last_check)}
                     </p>
+                    {channel.schedule_override && (
+                      <p className="flex items-center text-xs text-gray-500" title={`Custom cron schedule: ${channel.schedule_override}`}>
+                        <CalendarClockIcon className="h-4 w-4 mr-1.5 text-gray-400" />
+                        Custom schedule: {channel.schedule_override}
+                      </p>
+                    )}
                   </div>
 
                   {channel.last_run_status === 'failed' && channel.last_run_error && (

--- a/frontend/src/components/DownloadHistory.tsx
+++ b/frontend/src/components/DownloadHistory.tsx
@@ -10,6 +10,7 @@ import {
   ChevronRightIcon,
   ExternalLinkIcon,
   AlertCircleIcon,
+  RotateCcwIcon,
 } from 'lucide-react'
 
 /**
@@ -43,6 +44,7 @@ interface DownloadRecord {
   file_size?: number
   status: string
   error_message?: string
+  retry_count?: number
   file_exists: boolean
   deleted_at?: string
   created_at: string
@@ -143,6 +145,8 @@ export function DownloadHistory() {
   const [channelFilter, setChannelFilter] = useState('')
   const [statusFilter, setStatusFilter] = useState('')
   const [page, setPage] = useState(0)
+  const [retryingId, setRetryingId] = useState<number | null>(null)
+  const [retryError, setRetryError] = useState('')
 
   const fetchDownloads = useCallback(async () => {
     setIsLoading(true)
@@ -195,6 +199,30 @@ export function DownloadHistory() {
     }
     fetchChannels()
   }, [])
+
+  const handleRetry = async (download: DownloadRecord) => {
+    setRetryingId(download.id)
+    setRetryError('')
+    try {
+      const response = await fetch(`/api/v1/downloads/${download.id}/retry`, { method: 'POST' })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) {
+        throw new Error(data.detail || data.error || 'Retry failed')
+      }
+      if (!data.success) {
+        throw new Error(data.error_message || 'Download failed again')
+      }
+      await fetchDownloads()
+    } catch (err) {
+      setRetryError(
+        `Retry of "${download.title}" failed: ${err instanceof Error ? err.message : 'unknown error'}`
+      )
+      // Refresh anyway so retry_count/status reflect the attempt
+      await fetchDownloads()
+    } finally {
+      setRetryingId(null)
+    }
+  }
 
   const handleChannelFilterChange = (value: string) => {
     setChannelFilter(value)
@@ -276,6 +304,14 @@ export function DownloadHistory() {
           </div>
         )}
 
+        {/* Retry outcome */}
+        {retryError && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md flex items-start">
+            <AlertCircleIcon className="h-5 w-5 text-red-500 mr-2 flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-red-700">{retryError}</p>
+          </div>
+        )}
+
         {/* Loading state */}
         {isLoading ? (
           <div className="py-12 text-center text-gray-500">
@@ -334,10 +370,22 @@ export function DownloadHistory() {
                             {download.video_id}
                             <ExternalLinkIcon className="h-3 w-3 ml-1" />
                           </a>
-                          {download.status === 'failed' && download.error_message && (
-                            <p className="text-xs text-red-600 mt-1 break-words line-clamp-2" title={download.error_message}>
-                              {download.error_message}
-                            </p>
+                          {download.status === 'failed' && (
+                            <>
+                              {download.error_message && (
+                                <p className="text-xs text-red-600 mt-1 break-words line-clamp-2" title={download.error_message}>
+                                  {download.error_message}
+                                </p>
+                              )}
+                              <button
+                                onClick={() => handleRetry(download)}
+                                disabled={retryingId !== null}
+                                className="mt-1.5 inline-flex items-center px-2 py-1 rounded text-xs font-medium text-red-700 bg-red-50 hover:bg-red-100 border border-red-200 disabled:opacity-50 transition-colors"
+                              >
+                                <RotateCcwIcon className={`h-3 w-3 mr-1 ${retryingId === download.id ? 'animate-spin' : ''}`} />
+                                {retryingId === download.id ? 'Retrying...' : 'Retry'}
+                              </button>
+                            </>
                           )}
                         </div>
                       </td>

--- a/frontend/src/components/DownloadHistory.tsx
+++ b/frontend/src/components/DownloadHistory.tsx
@@ -11,6 +11,7 @@ import {
   ExternalLinkIcon,
   AlertCircleIcon,
   RotateCcwIcon,
+  XIcon,
 } from 'lucide-react'
 
 /**
@@ -227,11 +228,13 @@ export function DownloadHistory() {
   const handleChannelFilterChange = (value: string) => {
     setChannelFilter(value)
     setPage(0)
+    setRetryError('')
   }
 
   const handleStatusFilterChange = (value: string) => {
     setStatusFilter(value)
     setPage(0)
+    setRetryError('')
   }
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
@@ -304,11 +307,18 @@ export function DownloadHistory() {
           </div>
         )}
 
-        {/* Retry outcome */}
+        {/* Retry outcome (dismissible; also cleared when filters change) */}
         {retryError && (
           <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md flex items-start">
             <AlertCircleIcon className="h-5 w-5 text-red-500 mr-2 flex-shrink-0 mt-0.5" />
-            <p className="text-sm text-red-700">{retryError}</p>
+            <p className="text-sm text-red-700 flex-1">{retryError}</p>
+            <button
+              onClick={() => setRetryError('')}
+              aria-label="Dismiss retry error"
+              className="ml-2 text-red-400 hover:text-red-600 flex-shrink-0"
+            >
+              <XIcon className="h-4 w-4" />
+            </button>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Makes the scheduler honest: two cases where the data model promised behavior the code didn't deliver are now real. Implements per-video retry (part of US-013 manual control) and per-channel schedule overrides (US-016).

### Per-video retry

- **Within-run retry:** transient failures (network/timeout/rate-limit, classified by the shared `is_retryable_error` helper now in `utils.py`) are retried up to 2 extra times with a 10s backoff via the new `download_video_with_retry` wrapper. Permanent errors (private/deleted video) fail fast.
- **Cross-run cap:** new `retry_count` column on `downloads` (Alembic migration `b1c2d3e4f5a6` included) increments once per failed run; `should_download_video` stops auto-attempting a video after 5 failed runs. Previously a permanently broken video was silently re-attempted on every single run forever.
- **Manual retry:** `POST /api/v1/downloads/{id}/retry` resets the retry budget and immediately re-attempts the download. Returns 400 for non-failed downloads or disabled channels, 409 while a scheduled job is running. The History view gains a **Retry** button on failed rows with per-row progress and inline error reporting.

### Per-channel schedules (US-016)

- `schedule_override` is now **honored** instead of silently ignored:
  - `SchedulerService.sync_channel_schedule` creates/updates/removes a per-channel APScheduler cron job (`channel_download_job_{id}`) for each enabled channel with an override
  - `sync_all_channel_schedules` reconciles jobs with the database on startup, removing stale jobs for channels deleted/disabled/reverted while the app was down
  - Channel create/update/delete endpoints keep the jobs in sync (failures degrade to a warning — jobs are re-reconciled on next startup)
- The global scheduled job now excludes channels with an override (`get_channels_for_global_run`); blank overrides mean "use global schedule"
- Per-channel jobs share the `scheduled_downloads` lock with the global job, so runs never overlap — a per-channel run that collides simply skips to its next scheduled time
- `schedule_override` is validated as a cron expression at the API (same rules as the global schedule, including the 5-minute-minimum guard); blank values normalize to `null`
- Dashboard cards show a "Custom schedule: `<cron>`" indicator

**Deliberate scope cut:** no UI form for *setting* the override yet — it's settable via `PUT /channels/{id}` or YAML and visible on the dashboard. A "Set custom schedule" modal in the channel list is the planned follow-up, kept out to keep this PR reviewable.

## Testing

- **Backend: 308 passed.** 19 new tests in `test_retry_and_schedules.py`:
  - Retry endpoint: 404 / non-failed 400 / disabled-channel 400 / scheduler-running 409 / success path with budget reset
  - Retry policy: within-run attempt counts for transient vs permanent errors, retry_count increments once per run, success resets the budget, over-cap videos skipped by `should_download_video`
  - `get_channels_for_global_run`: override/blank/disabled selection
  - Override validation: invalid cron 400, every-minute guard, valid cron stored + job synced, blank normalizes to null
  - `SchedulerService` job sync (mocked scheduler): add/remove/replace semantics, invalid cron raises
- **Frontend: 45 passed.** 3 new tests: Retry button only on failed rows + POST call, retry failure surfaced, custom schedule indicator.
- Pre-existing failures on `main` (8 backend, 20 frontend, 1 TS error in `YouTubeDownloader.tsx`) unchanged.

## Deployment note

The new `retry_count` column ships with an Alembic migration (`b1c2d3e4f5a6`, `server_default='0'`) — existing databases upgrade in place on container start.

https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd)_