### PR TITLE
feat: add custom schedule modal for channels (completes US-016 UI)

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -1192,7 +1192,12 @@ def retry_download(download_id: int, db: Session = Depends(get_db)):
     if not channel.enabled:
         raise HTTPException(status_code=400, detail="Channel is disabled")
 
-    # Don't compete with a running scheduled job for the same channel/files
+    # Don't compete with a running scheduled job for the same channel/files.
+    # Note: this is a best-effort check, not a lock — a scheduled job could
+    # acquire the scheduled_downloads lock between this check and the download
+    # below. Worst case both attempt the same video and one becomes a no-op
+    # (download_video skips already-completed videos), so we accept the small
+    # window instead of holding the scheduler lock from a threadpool handler.
     running_flag = db.query(ApplicationSettings).filter(
         ApplicationSettings.key == "scheduled_downloads_running"
     ).first()

--- a/backend/app/scheduled_download_job.py
+++ b/backend/app/scheduled_download_job.py
@@ -222,6 +222,9 @@ async def channel_download_job(channel_id: int):
 
         logger.info(f"Starting per-channel scheduled download for '{channel.name}' (ID: {channel_id})")
 
+        # Shared lock: per-channel jobs serialize with the global job AND each
+        # other. Custom schedules control *when* a channel runs, not parallelism
+        # — sequential downloads are deliberate (one yt-dlp process at a time).
         with scheduler_lock(db, "scheduled_downloads"):
             success, videos_downloaded, error_message = await _process_channel_with_recovery(channel, db)
 

--- a/backend/app/scheduler_service.py
+++ b/backend/app/scheduler_service.py
@@ -61,6 +61,9 @@ class SchedulerService:
     container restarts.
     """
 
+    # Job id prefix for per-channel schedule override jobs (US-016)
+    CHANNEL_JOB_PREFIX = 'channel_download_job_'
+
     def __init__(self):
         """Initialize scheduler with production-ready configuration.
 
@@ -235,8 +238,6 @@ class SchedulerService:
         except Exception as e:
             logger.error(f"Failed to update download schedule: {e}")
             raise
-
-    CHANNEL_JOB_PREFIX = 'channel_download_job_'
 
     def sync_channel_schedule(self, channel_id: int, cron_expression: Optional[str], enabled: bool):
         """Create, update, or remove the per-channel download job (US-016).

--- a/frontend/src/__tests__/components/ScheduleOverrideModal.test.tsx
+++ b/frontend/src/__tests__/components/ScheduleOverrideModal.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ScheduleOverrideModal } from '../../components/ScheduleOverrideModal'
+
+/**
+ * ScheduleOverrideModal Tests (US-016: Schedule Configuration)
+ *
+ * Verifies:
+ * - Live validation feedback (valid + invalid expressions)
+ * - Save sends PUT with the cron expression and reports back via onSaved
+ * - "Use global schedule" clears the override (PUT null)
+ * - Save button gating on validation state
+ */
+
+function mockFetch({ valid = true, putOk = true } = {}) {
+  return jest.fn((url: string, options?: RequestInit) => {
+    if (url.startsWith('/api/v1/scheduler/validate')) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve(
+            valid
+              ? { valid: true, error: null, next_run: '2026-06-12T06:00:00+00:00', human_readable: 'Every 6 hours' }
+              : { valid: false, error: 'Invalid cron expression: bad field', human_readable: 'Invalid expression' }
+          ),
+      })
+    }
+    if (options?.method === 'PUT') {
+      return Promise.resolve({
+        ok: putOk,
+        json: () => Promise.resolve(putOk ? {} : { detail: 'Invalid schedule_override: rejected' }),
+      })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+}
+
+describe('ScheduleOverrideModal Component', () => {
+  const onClose = jest.fn()
+  const onSaved = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = mockFetch() as jest.Mock
+  })
+
+  it('renders channel name and schedule presets', () => {
+    render(
+      <ScheduleOverrideModal
+        channelId={1}
+        channelName="Mrs Rachel"
+        currentOverride={null}
+        onClose={onClose}
+        onSaved={onSaved}
+      />
+    )
+
+    expect(screen.getByText('Mrs Rachel')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Every 6 hours' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Daily at midnight' })).toBeInTheDocument()
+    // No override set yet, so clearing is disabled
+    expect(screen.getByRole('button', { name: /use global schedule/i })).toBeDisabled()
+  })
+
+  it('validates the expression and saves it', async () => {
+    render(
+      <ScheduleOverrideModal
+        channelId={7}
+        channelName="Test"
+        currentOverride={null}
+        onClose={onClose}
+        onSaved={onSaved}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Every 6 hours' }))
+
+    // Debounced validation runs and shows the description
+    await waitFor(() => {
+      expect(screen.getByText('Every 6 hours', { selector: 'p' })).toBeInTheDocument()
+    })
+
+    const saveButton = screen.getByRole('button', { name: /save schedule/i })
+    expect(saveButton).not.toBeDisabled()
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledWith('0 */6 * * *')
+      expect(onClose).toHaveBeenCalled()
+    })
+
+    const putCall = (global.fetch as jest.Mock).mock.calls.find((c) => c[1]?.method === 'PUT')
+    expect(putCall[0]).toBe('/api/v1/channels/7')
+    expect(JSON.parse(putCall[1].body)).toEqual({ schedule_override: '0 */6 * * *' })
+  })
+
+  it('shows the validation error and disables save for invalid expressions', async () => {
+    global.fetch = mockFetch({ valid: false }) as jest.Mock
+
+    render(
+      <ScheduleOverrideModal
+        channelId={7}
+        channelName="Test"
+        currentOverride={null}
+        onClose={onClose}
+        onSaved={onSaved}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText(/cron expression/i), {
+      target: { value: '99 99 * * *' },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid cron expression: bad field')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('button', { name: /save schedule/i })).toBeDisabled()
+    expect(onSaved).not.toHaveBeenCalled()
+  })
+
+  it('clears the override via "Use global schedule"', async () => {
+    render(
+      <ScheduleOverrideModal
+        channelId={7}
+        channelName="Test"
+        currentOverride="0 */2 * * *"
+        onClose={onClose}
+        onSaved={onSaved}
+      />
+    )
+
+    const clearButton = screen.getByRole('button', { name: /use global schedule/i })
+    expect(clearButton).not.toBeDisabled()
+    fireEvent.click(clearButton)
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledWith(null)
+    })
+
+    const putCall = (global.fetch as jest.Mock).mock.calls.find((c) => c[1]?.method === 'PUT')
+    expect(JSON.parse(putCall[1].body)).toEqual({ schedule_override: null })
+  })
+
+  it('surfaces a save error without closing the modal', async () => {
+    global.fetch = mockFetch({ putOk: false }) as jest.Mock
+
+    render(
+      <ScheduleOverrideModal
+        channelId={7}
+        channelName="Test"
+        currentOverride="0 */2 * * *"
+        onClose={onClose}
+        onSaved={onSaved}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /use global schedule/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid schedule_override: rejected')).toBeInTheDocument()
+    })
+    expect(onClose).not.toHaveBeenCalled()
+    expect(onSaved).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/ChannelsList.tsx
+++ b/frontend/src/components/ChannelsList.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react'
-import { YoutubeIcon, TrashIcon, CheckCircleIcon, EditIcon, CheckIcon, XIcon, RefreshCwIcon, AlertCircleIcon, HardDriveIcon, DownloadIcon, MoreVertical, FileText } from 'lucide-react'
+import { YoutubeIcon, TrashIcon, CheckCircleIcon, EditIcon, CheckIcon, XIcon, RefreshCwIcon, AlertCircleIcon, HardDriveIcon, DownloadIcon, MoreVertical, FileText, CalendarClockIcon } from 'lucide-react'
+import { ScheduleOverrideModal } from './ScheduleOverrideModal'
 
 /**
  * ChannelsList Component - Displays and manages YouTube channels with inline limit editing
@@ -40,6 +41,7 @@ interface Channel {
   created_at: string
   updated_at: string
   metadata_status: string
+  schedule_override?: string | null
   metadata_path?: string
   directory_path?: string
   last_metadata_update?: string
@@ -114,6 +116,10 @@ export function ChannelsList({
     channelName: '',
     deleteMedia: false
   })
+
+  // === CUSTOM SCHEDULE MODAL STATE (US-016) ===
+  // Channel whose custom schedule is being edited (null = modal closed)
+  const [scheduleModalChannel, setScheduleModalChannel] = useState<Channel | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
   const [deleteSuccess, setDeleteSuccess] = useState('')
 
@@ -795,6 +801,22 @@ export function ChannelsList({
                             Download recent videos
                           </button>
 
+                          {/* Custom schedule (US-016) */}
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              setScheduleModalChannel(channel)
+                              setOpenMenuChannelId(null)
+                            }}
+                            className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center"
+                          >
+                            <CalendarClockIcon className="h-4 w-4 mr-2" />
+                            Custom schedule
+                            {channel.schedule_override && (
+                              <span className="ml-auto h-2 w-2 rounded-full bg-red-500" title={`Custom: ${channel.schedule_override}`} />
+                            )}
+                          </button>
+
                           {/* Regenerate NFO files */}
                           <button
                             onClick={(e) => {
@@ -1106,6 +1128,19 @@ export function ChannelsList({
             </div>
           </div>
         </div>
+      )}
+
+      {/* === CUSTOM SCHEDULE MODAL (US-016) === */}
+      {scheduleModalChannel && (
+        <ScheduleOverrideModal
+          channelId={scheduleModalChannel.id}
+          channelName={scheduleModalChannel.name}
+          currentOverride={scheduleModalChannel.schedule_override}
+          onClose={() => setScheduleModalChannel(null)}
+          onSaved={(scheduleOverride) => {
+            onUpdateChannel?.(scheduleModalChannel.id, { schedule_override: scheduleOverride })
+          }}
+        />
       )}
     </div>
   )

--- a/frontend/src/components/DownloadHistory.tsx
+++ b/frontend/src/components/DownloadHistory.tsx
@@ -428,7 +428,10 @@ export function DownloadHistory() {
               </p>
               <div className="flex items-center space-x-2">
                 <button
-                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  onClick={() => {
+                    setPage((p) => Math.max(0, p - 1))
+                    setRetryError('')
+                  }}
                   disabled={page === 0 || isLoading}
                   className="inline-flex items-center px-3 py-1.5 rounded-md text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 disabled:opacity-50 transition-colors"
                 >
@@ -439,7 +442,10 @@ export function DownloadHistory() {
                   Page {page + 1} of {totalPages}
                 </span>
                 <button
-                  onClick={() => setPage((p) => p + 1)}
+                  onClick={() => {
+                    setPage((p) => p + 1)
+                    setRetryError('')
+                  }}
                   disabled={page + 1 >= totalPages || isLoading}
                   className="inline-flex items-center px-3 py-1.5 rounded-md text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 disabled:opacity-50 transition-colors"
                 >

--- a/frontend/src/components/ScheduleOverrideModal.tsx
+++ b/frontend/src/components/ScheduleOverrideModal.tsx
@@ -1,0 +1,227 @@
+import React, { useState, useEffect } from 'react'
+import { CalendarClockIcon, XIcon, CheckCircleIcon, AlertCircleIcon, Loader2Icon } from 'lucide-react'
+
+/**
+ * ScheduleOverrideModal - Set or clear a channel's custom download schedule
+ *
+ * Completes User Story 16 (Schedule Configuration): channels with a custom
+ * cron schedule run on their own scheduler job instead of the global one.
+ *
+ * Features:
+ * - Cron expression input with live (debounced) validation via the backend,
+ *   showing a human-readable description and the next run time
+ * - Common schedule presets for one-click selection
+ * - "Use global schedule" clears the override
+ * - Saves via PUT /api/v1/channels/{id} (which also syncs the scheduler job)
+ */
+
+interface ValidationResult {
+  valid: boolean
+  error?: string
+  next_run?: string
+  human_readable?: string
+}
+
+interface ScheduleOverrideModalProps {
+  channelId: number
+  channelName: string
+  currentOverride?: string | null
+  onClose: () => void
+  onSaved: (scheduleOverride: string | null) => void
+}
+
+const PRESETS = [
+  { label: 'Every 6 hours', expression: '0 */6 * * *' },
+  { label: 'Every hour', expression: '0 * * * *' },
+  { label: 'Daily at midnight', expression: '0 0 * * *' },
+  { label: 'Weekly on Sunday', expression: '0 0 * * 0' },
+]
+
+const VALIDATE_DEBOUNCE_MS = 400
+
+export function ScheduleOverrideModal({
+  channelId,
+  channelName,
+  currentOverride,
+  onClose,
+  onSaved,
+}: ScheduleOverrideModalProps) {
+  const [expression, setExpression] = useState(currentOverride || '')
+  const [validation, setValidation] = useState<ValidationResult | null>(null)
+  const [isValidating, setIsValidating] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState('')
+
+  // Debounced live validation against the backend
+  useEffect(() => {
+    if (!expression.trim()) {
+      setValidation(null)
+      return
+    }
+
+    setIsValidating(true)
+    const timer = setTimeout(async () => {
+      try {
+        const response = await fetch(
+          `/api/v1/scheduler/validate?expression=${encodeURIComponent(expression.trim())}`
+        )
+        const data = await response.json()
+        setValidation({
+          valid: !!data.valid,
+          error: data.error,
+          next_run: data.next_run,
+          human_readable: data.human_readable,
+        })
+      } catch {
+        setValidation({ valid: false, error: 'Could not validate expression' })
+      } finally {
+        setIsValidating(false)
+      }
+    }, VALIDATE_DEBOUNCE_MS)
+
+    return () => {
+      clearTimeout(timer)
+      setIsValidating(false)
+    }
+  }, [expression])
+
+  const save = async (override: string | null) => {
+    setIsSaving(true)
+    setSaveError('')
+    try {
+      const response = await fetch(`/api/v1/channels/${channelId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ schedule_override: override }),
+      })
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.detail || 'Failed to save schedule')
+      }
+      onSaved(override)
+      onClose()
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save schedule')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const trimmed = expression.trim()
+  const canSave = trimmed !== '' && validation?.valid === true && !isValidating && !isSaving
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6" role="dialog" aria-label="Custom schedule">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center">
+            <CalendarClockIcon className="h-5 w-5 mr-2 text-red-600" />
+            <h3 className="text-lg font-semibold text-gray-900">Custom Schedule</h3>
+          </div>
+          <button onClick={onClose} aria-label="Close" className="text-gray-400 hover:text-gray-600">
+            <XIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        <p className="text-sm text-gray-600 mb-4">
+          Set a cron schedule for <span className="font-medium">{channelName}</span>.
+          With a custom schedule, this channel runs on its own timing instead of the
+          global schedule.
+        </p>
+
+        {/* Presets */}
+        <div className="flex flex-wrap gap-2 mb-3">
+          {PRESETS.map((preset) => (
+            <button
+              key={preset.expression}
+              onClick={() => setExpression(preset.expression)}
+              className={`px-2.5 py-1 rounded-full text-xs font-medium border transition-colors ${
+                trimmed === preset.expression
+                  ? 'bg-red-600 text-white border-red-600'
+                  : 'bg-white text-gray-700 border-gray-300 hover:border-red-400'
+              }`}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Cron input */}
+        <label htmlFor="cron-expression" className="block text-sm font-medium text-gray-700 mb-1">
+          Cron expression (minute hour day month weekday)
+        </label>
+        <input
+          id="cron-expression"
+          type="text"
+          value={expression}
+          onChange={(e) => setExpression(e.target.value)}
+          placeholder="0 */6 * * *"
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm font-mono focus:border-red-500 focus:ring-red-500"
+        />
+
+        {/* Validation feedback */}
+        <div className="min-h-[2.5rem] mt-2">
+          {trimmed !== '' && (
+            isValidating ? (
+              <p className="flex items-center text-sm text-gray-500">
+                <Loader2Icon className="h-4 w-4 mr-1.5 animate-spin" />
+                Validating...
+              </p>
+            ) : validation?.valid ? (
+              <div className="text-sm text-green-700">
+                <p className="flex items-center font-medium">
+                  <CheckCircleIcon className="h-4 w-4 mr-1.5" />
+                  {validation.human_readable || 'Valid schedule'}
+                </p>
+                {validation.next_run && (
+                  <p className="text-xs text-gray-500 ml-5.5 mt-0.5">
+                    Next run: {new Date(validation.next_run).toLocaleString()}
+                  </p>
+                )}
+              </div>
+            ) : validation ? (
+              <p className="flex items-center text-sm text-red-600">
+                <AlertCircleIcon className="h-4 w-4 mr-1.5 flex-shrink-0" />
+                {validation.error || 'Invalid cron expression'}
+              </p>
+            ) : null
+          )}
+        </div>
+
+        {saveError && (
+          <div className="mt-2 p-2 bg-red-50 border border-red-200 rounded-md">
+            <p className="text-sm text-red-700">{saveError}</p>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-100">
+          <button
+            onClick={() => save(null)}
+            disabled={isSaving || !currentOverride}
+            title={currentOverride ? 'Remove the custom schedule' : 'No custom schedule set'}
+            className="text-sm text-gray-600 hover:text-gray-900 disabled:opacity-50 underline-offset-2 hover:underline"
+          >
+            Use global schedule
+          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onClose}
+              disabled={isSaving}
+              className="px-3 py-2 rounded-md text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 disabled:opacity-50 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => save(trimmed)}
+              disabled={!canSave}
+              className="px-3 py-2 rounded-md text-sm font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 transition-colors"
+            >
+              {isSaving ? 'Saving...' : 'Save schedule'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Completes **US-016 (Schedule Configuration)** by adding the UI for setting per-channel schedules — the piece deliberately deferred from #41 — and folds in the four polish items from #41's final review.

### Custom Schedule modal

- New `ScheduleOverrideModal` component, opened from a new **"Custom schedule"** item in each channel's kebab menu (with a red indicator dot when an override is set):
  - Cron expression input with **debounced live validation** against `GET /api/v1/scheduler/validate` — shows the human-readable description ("Every 6 hours") and the actual next run time before saving
  - One-click presets: every hour, every 6 hours, daily at midnight, weekly on Sunday
  - **"Use global schedule"** action clears the override (disabled when none is set)
  - Save goes through the existing `PUT /api/v1/channels/{id}`, which validates the cron server-side and syncs the per-channel APScheduler job (both shipped in #41), so changes take effect immediately
  - Save errors surface in the modal without closing it; parent channel state updates via the existing `onUpdateChannel` callback

### Deferred polish from #41's review

- `CHANNEL_JOB_PREFIX` moved to the top of `SchedulerService` with the other class-level constants
- Documented the benign race window between the retry endpoint's 409 check and the download attempt (worst case both attempt the same video and one becomes a no-op)
- Documented that per-channel jobs intentionally serialize via the shared `scheduled_downloads` lock — custom schedules control *when* a channel runs, not parallelism
- Retry error banner in Download History now clears when paging, not just when filters change

Note: the review's suggestion to remove the `_is_retryable_error` stub was not taken — existing unit tests (`test_scheduled_download_job.py`) exercise it directly.

## Testing

- **Frontend: 50 passed.** 5 new `ScheduleOverrideModal` tests: presets render, live validation + save flow (asserts the PUT payload), invalid expression disables save, clear-override flow (PUT `null`), save error surfaces without closing.
- **Backend: 308 passed** (comment-only changes).
- Pre-existing failures on `main` (8 backend, 20 frontend, 1 TS error in `YouTubeDownloader.tsx`) unchanged.

https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd)_