### PR TITLE
feat: quality presets end-to-end (US-015) + full test-suite repair

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -3,6 +3,7 @@ import os
 import re
 import glob
 import shutil
+import asyncio
 import logging
 from datetime import datetime
 from typing import List, Optional
@@ -18,7 +19,7 @@ from app.youtube_service import youtube_service
 from app.metadata_service import metadata_service
 from app.video_download_service import video_download_service
 from app.scheduled_download_job import cleanup_old_videos
-from app.utils import update_channel_in_yaml, remove_channel_from_yaml, sync_setting_to_yaml, get_default_video_limit as get_default_limit_setting, channel_dir_name
+from app.utils import update_channel_in_yaml, remove_channel_from_yaml, sync_setting_to_yaml, get_default_video_limit as get_default_limit_setting, get_default_quality_preset, channel_dir_name
 from app.schemas import (
     Channel as ChannelSchema,
     ChannelCreate,
@@ -27,6 +28,8 @@ from app.schemas import (
     SystemHealth,
     DefaultVideoLimitUpdate,
     DefaultVideoLimitResponse,
+    DefaultQualityUpdate,
+    DefaultQualityResponse,
     Download as DownloadSchema,
     DownloadList,
     DownloadWithChannel,
@@ -158,7 +161,11 @@ async def create_channel(channel: ChannelCreate, db: Session = Depends(get_db)):
     normalized_url = youtube_service.normalize_channel_url(str(channel.url))
     
     # Extract channel metadata using yt-dlp (Story 1: metadata only, no video downloads)
-    success, channel_info, error = youtube_service.extract_channel_info(normalized_url)
+    # Runs in a worker thread: yt-dlp network I/O is blocking and must not
+    # stall the event loop for other requests
+    success, channel_info, error = await asyncio.to_thread(
+        youtube_service.extract_channel_info, normalized_url
+    )
     if not success:
         raise HTTPException(status_code=400, detail=f"Failed to extract channel information: {error}")
     
@@ -179,7 +186,14 @@ async def create_channel(channel: ChannelCreate, db: Session = Depends(get_db)):
     if channel_limit is None:
         channel_limit = get_default_limit_setting(db)
         logger.info(f"Applied default video limit {channel_limit} to new channel: {channel_info['name']}")
-    
+
+    # === APPLY DEFAULT QUALITY PRESET (US-015) ===
+    # If no quality specified, use the global default setting
+    channel_quality = channel.quality_preset
+    if channel_quality is None:
+        channel_quality = get_default_quality_preset(db)
+        logger.info(f"Applied default quality preset '{channel_quality}' to new channel: {channel_info['name']}")
+
     # Create new channel record with extracted YouTube metadata
     db_channel = Channel(
         url=normalized_url,                              # Normalized URL for consistency
@@ -188,7 +202,7 @@ async def create_channel(channel: ChannelCreate, db: Session = Depends(get_db)):
         limit=channel_limit,                             # User-specified or default video limit
         enabled=channel.enabled,                         # Monitoring enabled/disabled
         schedule_override=channel.schedule_override,     # Custom schedule (if any)
-        quality_preset=channel.quality_preset,          # Video quality preference
+        quality_preset=channel_quality,                  # User-specified or default quality
         metadata_status="pending",                       # Initial metadata status
     )
     
@@ -198,8 +212,11 @@ async def create_channel(channel: ChannelCreate, db: Session = Depends(get_db)):
     db.refresh(db_channel)  # Refresh to get auto-generated fields (id, timestamps)
     
     # === METADATA PROCESSING (Story 004) ===
-    # Process complete channel metadata including directory creation and image downloads
-    metadata_success, metadata_errors = metadata_service.process_channel_metadata(db, db_channel, normalized_url)
+    # Process complete channel metadata including directory creation and image
+    # downloads (blocking network/disk I/O → worker thread)
+    metadata_success, metadata_errors = await asyncio.to_thread(
+        metadata_service.process_channel_metadata, db, db_channel, normalized_url
+    )
     
     if not metadata_success:
         logger.warning(f"Metadata processing failed for channel {db_channel.id}: {metadata_errors}")
@@ -212,7 +229,10 @@ async def create_channel(channel: ChannelCreate, db: Session = Depends(get_db)):
         logger.info(f"📝 API: Channel details - ID: {db_channel.id}, URL: {db_channel.url}, channel_id: {db_channel.channel_id}, limit: {db_channel.limit}")
         try:
             logger.info(f"🔄 API: Calling video_download_service.process_channel_downloads()...")
-            download_success, videos_downloaded, download_error = video_download_service.process_channel_downloads(db_channel, db)
+            # Worker thread: initial downloads can take minutes of blocking yt-dlp work
+            download_success, videos_downloaded, download_error = await asyncio.to_thread(
+                video_download_service.process_channel_downloads, db_channel, db
+            )
             logger.info(f"✅ API: process_channel_downloads() returned - success: {download_success}, count: {videos_downloaded}, error: {download_error}")
             if download_success:
                 logger.info(f"✅ API: Initial download completed for {db_channel.name}: {videos_downloaded} videos downloaded")
@@ -340,14 +360,18 @@ async def update_channel(
 
 
 @router.post("/channels/{channel_id}/refresh-metadata")
-async def refresh_channel_metadata(channel_id: int, db: Session = Depends(get_db)):
+def refresh_channel_metadata(channel_id: int, db: Session = Depends(get_db)):
     """
     Refresh channel metadata including directory structure and images.
-    
+
     This endpoint implements metadata refresh functionality for Story 004.
     It extracts fresh metadata from YouTube, updates the JSON file,
     and redownloads cover/backdrop images.
-    
+
+    Declared sync (not async) on purpose: the refresh is blocking
+    network/disk I/O, so FastAPI runs it in the threadpool instead of
+    stalling the event loop.
+
     Args:
         channel_id: Database ID of channel to refresh
         
@@ -379,12 +403,16 @@ async def refresh_channel_metadata(channel_id: int, db: Session = Depends(get_db
 
 
 @router.post("/channels/{channel_id}/reindex")
-async def reindex_channel(channel_id: int, db: Session = Depends(get_db)):
+def reindex_channel(channel_id: int, db: Session = Depends(get_db)):
     """
     Reindex a channel's media folder to sync database with disk state.
 
     Protected by an application-level lock (same mechanism as the scheduler)
     so concurrent reindex operations cannot create duplicate records.
+
+    Declared sync (not async) on purpose: the reindex walks the media tree
+    and probes files (blocking disk I/O), so FastAPI runs it in the
+    threadpool instead of stalling the event loop.
 
     This will:
     - Find all video files on disk
@@ -787,6 +815,88 @@ async def update_default_video_limit(
         )
 
 
+@router.get("/settings/default-quality", response_model=DefaultQualityResponse, tags=["Settings"])
+async def get_default_quality(db: Session = Depends(get_db)):
+    """
+    Get the default video quality preset for new channels (US-015).
+
+    Applied automatically when channels are created without an explicit
+    quality_preset. Existing channels are unaffected by changes.
+
+    Example:
+        GET /api/v1/settings/default-quality
+        Response: {"quality": "best", "description": "...", "updated_at": "..."}
+    """
+    setting = db.query(ApplicationSettings).filter(
+        ApplicationSettings.key == 'default_quality_preset'
+    ).first()
+
+    return DefaultQualityResponse(
+        quality=setting.value if setting and setting.value else 'best',
+        description=(setting.description if setting else None) or "Default video quality preset for new channels",
+        updated_at=setting.updated_at if setting else None,
+    )
+
+
+@router.put("/settings/default-quality", response_model=DefaultQualityResponse, tags=["Settings"])
+async def update_default_quality(
+    setting_update: DefaultQualityUpdate,
+    db: Session = Depends(get_db)
+):
+    """
+    Update the default video quality preset for new channels (US-015).
+
+    Applies to channels created after this change; existing channels keep
+    their current quality_preset. Value is validated against the supported
+    presets by the request schema (422 on unknown values).
+
+    Example:
+        PUT /api/v1/settings/default-quality
+        Body: {"quality": "1080p"}
+    """
+    try:
+        setting = db.query(ApplicationSettings).filter(
+            ApplicationSettings.key == 'default_quality_preset'
+        ).first()
+
+        if setting:
+            setting.value = setting_update.quality
+            setting.updated_at = datetime.utcnow()
+        else:
+            setting = ApplicationSettings(
+                key='default_quality_preset',
+                value=setting_update.quality,
+                description='Default video quality preset for new channels',
+                created_at=datetime.utcnow(),
+                updated_at=datetime.utcnow(),
+            )
+            db.add(setting)
+
+        db.commit()
+        db.refresh(setting)
+        logger.info(f"Default quality preset updated to '{setting_update.quality}'")
+
+        # Sync to YAML configuration (supplementary; DB is source of truth)
+        try:
+            sync_setting_to_yaml('default_quality_preset', setting_update.quality)
+        except Exception as e:
+            logger.warning(f"YAML sync failed for default quality preset: {e}")
+
+        return DefaultQualityResponse(
+            quality=setting.value,
+            description=setting.description or "Default video quality preset for new channels",
+            updated_at=setting.updated_at,
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to update default quality preset: {e}")
+        db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail="Internal server error while updating default quality preset"
+        )
+
+
 # === DOWNLOAD ENDPOINTS (User Story 5) ===
 
 @router.post("/channels/{channel_id}/download", response_model=DownloadTriggerResponse)
@@ -884,8 +994,11 @@ async def trigger_channel_download(channel_id: int, db: Session = Depends(get_db
 
     # === IMMEDIATE EXECUTION (Scheduler not running) ===
     try:
-        # Process channel downloads using the video download service
-        success, videos_downloaded, error_message = video_download_service.process_channel_downloads(channel, db)
+        # Process channel downloads in a worker thread — this is minutes of
+        # blocking yt-dlp work that must not stall the event loop
+        success, videos_downloaded, error_message = await asyncio.to_thread(
+            video_download_service.process_channel_downloads, channel, db
+        )
 
         # === AUTOMATIC VIDEO CLEANUP ===
         # Clean up old videos if channel exceeds configured limit

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -206,9 +207,20 @@ async def create_channel(channel: ChannelCreate, db: Session = Depends(get_db)):
         metadata_status="pending",                       # Initial metadata status
     )
     
-    # Persist to database
-    db.add(db_channel)
-    db.commit()
+    # Persist to database. The duplicate check above is not atomic with this
+    # commit: now that metadata extraction runs in a worker thread, two
+    # near-simultaneous requests for the same channel can both pass the check.
+    # The unique constraint on channel_id is the real guard — translate its
+    # violation into the same friendly 400 the check produces.
+    try:
+        db.add(db_channel)
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=400,
+            detail="This channel is already being monitored (it was added by a concurrent request)."
+        )
     db.refresh(db_channel)  # Refresh to get auto-generated fields (id, timestamps)
     
     # === METADATA PROCESSING (Story 004) ===

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -6,9 +6,12 @@ from app.config import get_settings
 settings = get_settings()
 
 # Create SQLAlchemy engine
+# timeout: how long a connection waits on a locked database before raising
+# "database is locked". Matters now that request handlers run blocking work
+# in threadpool threads and can genuinely overlap as concurrent writers.
 engine = create_engine(
     settings.database_url,
-    connect_args={"check_same_thread": False} if "sqlite" in settings.database_url else {}
+    connect_args={"check_same_thread": False, "timeout": 15} if "sqlite" in settings.database_url else {}
 )
 
 # Create SessionLocal class

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,7 +1,11 @@
 """Pydantic schemas for API request/response validation."""
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional, List, Literal
 from pydantic import BaseModel, HttpUrl, Field
+
+# Quality presets supported by the download pipeline (US-015).
+# Must stay in sync with VideoDownloadService.QUALITY_FORMATS.
+QualityPreset = Literal['best', '2160p', '1080p', '720p', '480p']
 
 
 # Base schemas for common patterns
@@ -28,7 +32,7 @@ class ChannelCreate(BaseModel):
     limit: Optional[int] = Field(None, ge=1, le=100, description="Maximum videos to keep (uses default if not specified)")
     enabled: bool = Field(default=True, description="Whether channel monitoring is enabled")
     schedule_override: Optional[str] = Field(None, description="Custom cron schedule for this channel")
-    quality_preset: str = Field(default="best", description="Video quality preset")
+    quality_preset: Optional[QualityPreset] = Field(None, description="Video quality preset (uses global default if not specified)")
 
 
 class ChannelUpdate(BaseModel):
@@ -37,7 +41,7 @@ class ChannelUpdate(BaseModel):
     limit: Optional[int] = Field(None, ge=1, le=100)
     enabled: Optional[bool] = None
     schedule_override: Optional[str] = None
-    quality_preset: Optional[str] = None
+    quality_preset: Optional[QualityPreset] = None
 
 
 class Channel(ChannelBase, TimestampMixin):
@@ -322,6 +326,22 @@ class DashboardResponse(BaseModel):
     totals: DashboardTotals
     channels: List[ChannelDashboardItem]
     generated_at: datetime
+
+
+# Default quality preset schemas (US-015)
+class DefaultQualityUpdate(BaseModel):
+    """Schema for updating the default quality preset for new channels."""
+    quality: QualityPreset = Field(..., description="Default quality preset for new channels")
+
+
+class DefaultQualityResponse(BaseModel):
+    """Schema for default quality preset responses."""
+    quality: str = Field(..., description="Current default quality preset")
+    description: str = Field(..., description="Setting description")
+    updated_at: Optional[datetime] = Field(None, description="When setting was last updated")
+
+    class Config:
+        from_attributes = True
 
 
 # Error response schemas

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -580,9 +580,10 @@ def get_default_quality_preset(db_session=None) -> str:
     """
     Get the default video quality preset for new channels (US-015).
 
-    Priority order:
+    Priority order (same 3-tier scheme as get_default_video_limit):
     1. Database application_settings table (default_quality_preset)
-    2. Hardcoded fallback ('best')
+    2. YAML configuration file (supports US-008 file-based configuration)
+    3. Hardcoded fallback ('best')
 
     Args:
         db_session: Optional database session for direct queries
@@ -598,6 +599,12 @@ def get_default_quality_preset(db_session=None) -> str:
             ).first()
             if setting and setting.value:
                 return setting.value
+
+        # Fallback to YAML configuration (advanced users may edit the file
+        # directly without ever using the settings API)
+        config = load_yaml_config()
+        if 'settings' in config and config['settings'].get('default_quality_preset'):
+            return str(config['settings']['default_quality_preset'])
     except Exception as e:
         logger.warning(f"Failed to read default quality preset, using 'best': {e}")
 

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -574,3 +574,31 @@ def is_retryable_error(error_message: str) -> bool:
 
     error_lower = error_message.lower()
     return any(keyword in error_lower for keyword in retryable_keywords)
+
+
+def get_default_quality_preset(db_session=None) -> str:
+    """
+    Get the default video quality preset for new channels (US-015).
+
+    Priority order:
+    1. Database application_settings table (default_quality_preset)
+    2. Hardcoded fallback ('best')
+
+    Args:
+        db_session: Optional database session for direct queries
+
+    Returns:
+        str: Quality preset name (e.g., 'best', '1080p')
+    """
+    try:
+        if db_session:
+            from app.models import ApplicationSettings
+            setting = db_session.query(ApplicationSettings).filter(
+                ApplicationSettings.key == 'default_quality_preset'
+            ).first()
+            if setting and setting.value:
+                return setting.value
+    except Exception as e:
+        logger.warning(f"Failed to read default quality preset, using 'best': {e}")
+
+    return 'best'

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -44,6 +44,18 @@ class VideoDownloadService:
     # Used for file detection, verification, and .info.json path derivation
     VIDEO_EXTENSIONS = ('.mkv', '.mp4', '.webm', '.avi', '.mov', '.flv', '.m4v', '.3gp')
 
+    # Quality preset → yt-dlp format string (US-015).
+    # Each capped preset falls back to progressively lower quality and finally
+    # to best-available, so downloads degrade gracefully when the preferred
+    # quality doesn't exist for a video.
+    QUALITY_FORMATS = {
+        'best': 'bv*+ba/b',
+        '2160p': 'bv*[height<=2160]+ba/b[height<=2160]/bv*+ba/b',
+        '1080p': 'bv*[height<=1080]+ba/b[height<=1080]/bv*+ba/b',
+        '720p': 'bv*[height<=720]+ba/b[height<=720]/bv*+ba/b',
+        '480p': 'bv*[height<=480]+ba/b[height<=480]/bv*+ba/b',
+    }
+
     # Per-video retry policy:
     # - Within a run: retry transient failures up to WITHIN_RUN_RETRIES extra
     #   times with a short backoff (handles brief network hiccups)
@@ -928,6 +940,25 @@ class VideoDownloadService:
         logger.error("All extraction attempts failed")
         return False, [], "Could not extract videos using any method"
     
+    def format_for_quality(self, quality_preset: Optional[str]) -> str:
+        """
+        Resolve a channel's quality preset to a yt-dlp format string (US-015).
+
+        Args:
+            quality_preset: Preset name ('best', '2160p', '1080p', '720p', '480p')
+
+        Returns:
+            yt-dlp format string; unknown/missing presets resolve to 'best'
+        """
+        if quality_preset in self.QUALITY_FORMATS:
+            return self.QUALITY_FORMATS[quality_preset]
+
+        if quality_preset:
+            logger.warning(
+                f"Unknown quality preset '{quality_preset}', falling back to 'best'"
+            )
+        return self.QUALITY_FORMATS['best']
+
     def download_video_with_retry(self, video_info: Dict, channel: Channel, db: Session) -> Tuple[bool, Optional[str]]:
         """
         Download a single video, retrying transient failures within the run.
@@ -1025,9 +1056,12 @@ class VideoDownloadService:
                 db.add(download)
             
             db.commit()
-            
+
             # Configure yt-dlp for this specific video
             opts = self.download_opts.copy()
+            # Apply the channel's quality preset (US-015); unknown presets
+            # fall back to 'best' with a warning rather than failing
+            opts['format'] = self.format_for_quality(channel.quality_preset)
             video_url = f"https://www.youtube.com/watch?v={video_id}"
 
             # Verify the cookie file referenced in options is still present on disk

--- a/backend/tests/integration/test_dashboard_api.py
+++ b/backend/tests/integration/test_dashboard_api.py
@@ -144,6 +144,21 @@ class TestDashboardEndpoint:
             assert 0 <= disk["usage_percent"] <= 100
             assert disk["warning"] == (disk["usage_percent"] >= 80.0)
 
+    def test_disk_block_null_when_media_dir_unavailable(
+        self, test_client: TestClient, dashboard_fixture
+    ):
+        """If the media volume can't be read, disk degrades to null (not a 500)."""
+        from unittest.mock import patch
+
+        with patch("app.api.shutil.disk_usage", side_effect=OSError("not mounted")):
+            response = test_client.get("/api/v1/dashboard")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["disk"] is None
+        # The rest of the payload is unaffected
+        assert data["totals"]["channels"] == 3
+
     def test_empty_database(self, test_client: TestClient):
         response = test_client.get("/api/v1/dashboard")
 

--- a/backend/tests/integration/test_download_history_management.py
+++ b/backend/tests/integration/test_download_history_management.py
@@ -112,10 +112,15 @@ class TestDownloadHistoryManagement:
         # Mock database query returns None (no existing record)
         mock_db.query.return_value.filter.return_value.first.return_value = None
         
-        # Mock file found on disk
-        with patch.object(service, 'check_video_on_disk', return_value=True):
+        # Mock file found on disk with valid metadata. should_download_video
+        # uses _find_video_file_path + extract_video_metadata (not the legacy
+        # check_video_on_disk) to detect and register on-disk videos.
+        with patch.object(service, '_find_video_file_path',
+                          return_value='/fake/path/video [testVideo123].mkv'), \
+                patch.object(service, 'extract_video_metadata',
+                             return_value={'title': 'Test Video', 'upload_date': '20240101'}):
             should_download, existing_download = service.should_download_video(video_id, test_channel, mock_db)
-        
+
         assert should_download is False  # Should skip - found on disk
         # Verify database record was created
         mock_db.add.assert_called()

--- a/backend/tests/integration/test_metadata_workflow.py
+++ b/backend/tests/integration/test_metadata_workflow.py
@@ -80,36 +80,46 @@ def sample_channel_data():
 class TestMetadataWorkflowIntegration:
     """Integration tests for metadata workflow."""
     
-    def test_create_channel_triggers_metadata_processing(self, test_client, test_db_session, 
+    def test_create_channel_triggers_metadata_processing(self, test_client, test_db_session,
                                                         sample_channel_data):
         """Test that creating a channel triggers metadata processing."""
-        with patch('app.youtube_service.youtube_service.extract_channel_info') as mock_extract:
-            with patch('app.metadata_service.metadata_service.process_channel_metadata') as mock_process:
-                
-                # Mock YouTube service response
-                mock_extract.return_value = (True, {
-                    'channel_id': 'UC123456789',
-                    'name': 'Test Channel'
-                }, None)
-                
-                # Mock metadata processing success
-                mock_process.return_value = (True, [])
-                
-                # Create channel via API
-                response = test_client.post("/api/v1/channels", json=sample_channel_data)
-                
-                assert response.status_code == 200
-                channel_data = response.json()
-                
-                # Verify channel was created
-                assert channel_data['name'] == 'Test Channel'
-                assert channel_data['channel_id'] == 'UC123456789'
-                assert channel_data['metadata_status'] == 'completed'  # Should be updated by process
-                
-                # Verify metadata processing was triggered
-                mock_process.assert_called_once()
-                call_args = mock_process.call_args[0]
-                assert call_args[1].id == channel_data['id']  # Channel instance
+        with patch('app.youtube_service.youtube_service.extract_channel_info') as mock_extract, \
+                patch('app.metadata_service.metadata_service.process_channel_metadata') as mock_process, \
+                patch('app.api.video_download_service.process_channel_downloads') as mock_downloads:
+
+            # Mock YouTube service response
+            mock_extract.return_value = (True, {
+                'channel_id': 'UC123456789',
+                'name': 'Test Channel'
+            }, None)
+
+            # Mock metadata processing success. The 'completed' status is set
+            # INSIDE the real service, so the mock must simulate that side
+            # effect for the response to reflect it.
+            def fake_process(db, channel, url):
+                channel.metadata_status = 'completed'
+                db.commit()
+                return (True, [])
+            mock_process.side_effect = fake_process
+
+            # Prevent real yt-dlp network calls for initial downloads
+            mock_downloads.return_value = (True, 0, None)
+
+            # Create channel via API
+            response = test_client.post("/api/v1/channels", json=sample_channel_data)
+
+            assert response.status_code == 200
+            channel_data = response.json()
+
+            # Verify channel was created
+            assert channel_data['name'] == 'Test Channel'
+            assert channel_data['channel_id'] == 'UC123456789'
+            assert channel_data['metadata_status'] == 'completed'  # Set by (mocked) process
+
+            # Verify metadata processing was triggered
+            mock_process.assert_called_once()
+            call_args = mock_process.call_args[0]
+            assert call_args[1].id == channel_data['id']  # Channel instance
     
     def test_refresh_metadata_endpoint(self, test_client, test_db_session, sample_channel_data):
         """Test metadata refresh endpoint functionality."""
@@ -136,9 +146,13 @@ class TestMetadataWorkflowIntegration:
             assert response.status_code == 200
             result = response.json()
             assert result['message'] == 'Channel metadata refreshed successfully'
-            
-            # Verify refresh was called
-            mock_refresh.assert_called_once_with(test_db_session, channel)
+
+            # Verify refresh was called. The endpoint uses its own
+            # request-scoped session (and channel instance loaded from it),
+            # so compare by id rather than object identity.
+            mock_refresh.assert_called_once()
+            call_args = mock_refresh.call_args[0]
+            assert call_args[1].id == channel.id
     
     def test_refresh_metadata_endpoint_failure(self, test_client, test_db_session):
         """Test metadata refresh endpoint error handling."""
@@ -301,31 +315,34 @@ class TestMetadataWorkflowErrorScenarios:
             assert len(result['warnings']) == 1
             assert "Image download" in result['warnings'][0]
     
-    def test_metadata_workflow_database_rollback(self, test_client, test_db_session, sample_channel_data):
-        """Test that database operations are properly rolled back on failure."""
+    def test_metadata_workflow_database_rollback(self, test_db_session, sample_channel_data):
+        """Test that an unexpected metadata-processing exception yields a 500."""
+        # TestClient re-raises server exceptions by default, which would fail
+        # the test before we can assert on the response — disable that so the
+        # unhandled exception surfaces as the 500 the client would see.
+        client = TestClient(app, raise_server_exceptions=False)
+
         with patch('app.youtube_service.youtube_service.extract_channel_info') as mock_extract:
             with patch('app.metadata_service.metadata_service.process_channel_metadata') as mock_process:
-                
+
                 # Mock successful channel extraction
                 mock_extract.return_value = (True, {
-                    'channel_id': 'UC123456789', 
+                    'channel_id': 'UC123456789',
                     'name': 'Test Channel'
                 }, None)
-                
+
                 # Mock metadata processing that raises exception
                 mock_process.side_effect = Exception("Unexpected error during metadata processing")
-                
+
                 # Try to create channel
-                response = test_client.post("/api/v1/channels", json=sample_channel_data)
-                
+                response = client.post("/api/v1/channels", json=sample_channel_data)
+
                 # Should get a 500 error due to unhandled exception
                 assert response.status_code == 500
-                
-                # Verify channel was not persisted in database
-                channels = test_db_session.query(Channel).all()
-                # Channel might be created but metadata processing failed
-                # The exact behavior depends on implementation details
-                # This test ensures we handle the error gracefully
+
+                # The channel row itself is committed before metadata
+                # processing; this test ensures the error surfaces as a 500
+                # rather than crashing the app
 
 
 class TestMetadataWorkflowPerformance:

--- a/backend/tests/integration/test_quality_preset.py
+++ b/backend/tests/integration/test_quality_preset.py
@@ -1,0 +1,126 @@
+"""Tests for video quality presets (US-015: Download Quality Configuration)."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import Channel, ApplicationSettings
+from app.video_download_service import VideoDownloadService, video_download_service
+
+
+@pytest.fixture
+def channel(db_session):
+    channel = Channel(
+        url="https://youtube.com/@qualitychannel",
+        name="Quality Channel",
+        channel_id="UCqualityaaaaaaaaaaaaa",
+        limit=10,
+        enabled=True,
+        quality_preset="720p",
+        metadata_status="completed",
+    )
+    db_session.add(channel)
+    db_session.commit()
+    db_session.refresh(channel)
+    return channel
+
+
+class TestQualityFormatMapping:
+    """format_for_quality resolves presets to yt-dlp format strings."""
+
+    @pytest.mark.parametrize("preset", ["best", "2160p", "1080p", "720p", "480p"])
+    def test_known_presets_resolve(self, preset):
+        fmt = video_download_service.format_for_quality(preset)
+        assert fmt == VideoDownloadService.QUALITY_FORMATS[preset]
+
+    def test_capped_presets_fall_back_to_best_available(self):
+        # Each capped preset must end with the unconditional best-available
+        # alternative so downloads degrade gracefully (US-015 acceptance)
+        for preset, fmt in VideoDownloadService.QUALITY_FORMATS.items():
+            if preset != "best":
+                assert fmt.endswith("/bv*+ba/b"), f"{preset} lacks best-available fallback"
+
+    def test_unknown_preset_falls_back_to_best(self):
+        assert video_download_service.format_for_quality("potato") == VideoDownloadService.QUALITY_FORMATS["best"]
+
+    def test_none_preset_falls_back_to_best(self):
+        assert video_download_service.format_for_quality(None) == VideoDownloadService.QUALITY_FORMATS["best"]
+
+
+class TestDownloadUsesChannelPreset:
+    """download_video must pass the channel's preset format to yt-dlp."""
+
+    def test_download_opts_use_channel_quality(self, db_session: Session, channel):
+        captured_opts = {}
+
+        class FakeYoutubeDL:
+            def __init__(self, opts):
+                captured_opts.update(opts)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def download(self, urls):
+                pass
+
+        video_info = {"id": "vid_quality_1", "title": "Quality Test"}
+        with patch("app.video_download_service.yt_dlp.YoutubeDL", FakeYoutubeDL):
+            video_download_service.download_video(video_info, channel, db_session)
+
+        assert captured_opts["format"] == VideoDownloadService.QUALITY_FORMATS["720p"]
+
+
+class TestChannelQualityValidation:
+    """Channel create/update must reject unsupported presets."""
+
+    def test_update_rejects_unknown_preset(self, test_client: TestClient, channel):
+        response = test_client.put(
+            f"/api/v1/channels/{channel.id}",
+            json={"quality_preset": "4k-ultra"},
+        )
+        assert response.status_code == 422
+
+    def test_update_accepts_supported_preset(self, test_client: TestClient, db_session, channel):
+        response = test_client.put(
+            f"/api/v1/channels/{channel.id}",
+            json={"quality_preset": "1080p"},
+        )
+        assert response.status_code == 200
+        db_session.refresh(channel)
+        assert channel.quality_preset == "1080p"
+
+
+class TestDefaultQualitySetting:
+    """GET/PUT /settings/default-quality (global default for new channels)."""
+
+    def test_get_returns_best_when_unset(self, test_client: TestClient):
+        response = test_client.get("/api/v1/settings/default-quality")
+        assert response.status_code == 200
+        assert response.json()["quality"] == "best"
+
+    def test_put_persists_and_get_reflects(self, test_client: TestClient, db_session):
+        response = test_client.put(
+            "/api/v1/settings/default-quality",
+            json={"quality": "1080p"},
+        )
+        assert response.status_code == 200
+        assert response.json()["quality"] == "1080p"
+
+        response = test_client.get("/api/v1/settings/default-quality")
+        assert response.json()["quality"] == "1080p"
+
+        setting = db_session.query(ApplicationSettings).filter(
+            ApplicationSettings.key == "default_quality_preset"
+        ).first()
+        assert setting.value == "1080p"
+
+    def test_put_rejects_unknown_preset(self, test_client: TestClient):
+        response = test_client.put(
+            "/api/v1/settings/default-quality",
+            json={"quality": "potato"},
+        )
+        assert response.status_code == 422

--- a/backend/tests/integration/test_quality_preset.py
+++ b/backend/tests/integration/test_quality_preset.py
@@ -94,6 +94,45 @@ class TestChannelQualityValidation:
         assert channel.quality_preset == "1080p"
 
 
+class TestCreateChannelRace:
+    """Regression test for the create-channel TOCTOU race.
+
+    With blocking work moved to worker threads, two requests for the same
+    channel can both pass the duplicate check before either commits. The
+    unique constraint must then surface as a friendly 400, not a 500.
+    """
+
+    def test_concurrent_duplicate_creation_returns_400(self, test_client: TestClient, db_session: Session):
+        channel_info = {"channel_id": "UCraceaaaaaaaaaaaaaaaa", "name": "Race Channel"}
+
+        def insert_conflicting_channel(db):
+            # Simulates the concurrent request winning the race in the window
+            # between the duplicate check and this request's commit
+            db_session.add(Channel(
+                url="https://youtube.com/@race-winner",
+                name="Race Channel",
+                channel_id=channel_info["channel_id"],
+                limit=10,
+                enabled=True,
+            ))
+            db_session.commit()
+            return 'best'
+
+        with patch("app.api.youtube_service.normalize_channel_url",
+                   return_value="https://youtube.com/@race-loser"), \
+                patch("app.api.youtube_service.extract_channel_info",
+                      return_value=(True, channel_info, None)), \
+                patch("app.api.get_default_quality_preset",
+                      side_effect=insert_conflicting_channel):
+            response = test_client.post(
+                "/api/v1/channels",
+                json={"url": "https://youtube.com/@race-loser"},
+            )
+
+        assert response.status_code == 400
+        assert "already being monitored" in response.json()["detail"]
+
+
 class TestDefaultQualitySetting:
     """GET/PUT /settings/default-quality (global default for new channels)."""
 

--- a/backend/tests/unit/test_scheduled_download_job.py
+++ b/backend/tests/unit/test_scheduled_download_job.py
@@ -567,23 +567,28 @@ class TestCleanupOldVideos:
         # Verify 3 oldest videos were deleted
         assert deleted_count == 3
 
-        # Verify correct number of videos remain
+        # Cleanup soft-deletes (file_exists=False + deleted_at set, row kept
+        # for history) — count only active videos
         remaining_count = db_session.query(Download).filter(
-            Download.channel_id == channel.id
+            Download.channel_id == channel.id,
+            Download.file_exists == True,
+            Download.deleted_at.is_(None)
         ).count()
         assert remaining_count == 10
 
-        # Verify oldest videos were deleted (video_0, video_1, video_2)
+        # Verify oldest videos were soft-deleted (video_0, video_1, video_2)
         oldest_videos = db_session.query(Download).filter(
             Download.channel_id == channel.id,
             Download.video_id.in_(["video_0", "video_1", "video_2"])
         ).all()
-        assert len(oldest_videos) == 0
+        assert all(not v.file_exists and v.deleted_at is not None for v in oldest_videos)
 
-        # Verify newest videos were kept (video_10, video_11, video_12)
+        # Verify newest videos were kept active (video_10, video_11, video_12)
         newest_videos = db_session.query(Download).filter(
             Download.channel_id == channel.id,
-            Download.video_id.in_(["video_10", "video_11", "video_12"])
+            Download.video_id.in_(["video_10", "video_11", "video_12"]),
+            Download.file_exists == True,
+            Download.deleted_at.is_(None)
         ).all()
         assert len(newest_videos) == 3
 
@@ -665,17 +670,22 @@ class TestCleanupOldVideos:
         # Verify 5 videos were deleted
         assert deleted_count == 5
 
-        # Verify ALL NULL videos were deleted (priority deletion)
-        null_videos = db_session.query(Download).filter(
+        # Verify ALL NULL videos were soft-deleted first (priority deletion).
+        # Cleanup keeps rows for history: file_exists=False + deleted_at set
+        active_null_videos = db_session.query(Download).filter(
             Download.channel_id == channel.id,
-            Download.upload_date.is_(None)
+            Download.upload_date.is_(None),
+            Download.file_exists == True,
+            Download.deleted_at.is_(None)
         ).all()
-        assert len(null_videos) == 0, "All NULL upload_date videos should be deleted first"
+        assert len(active_null_videos) == 0, "All NULL upload_date videos should be deleted first"
 
-        # Verify ALL dated videos were kept
+        # Verify ALL dated videos were kept active
         dated_videos = db_session.query(Download).filter(
             Download.channel_id == channel.id,
-            Download.upload_date.isnot(None)
+            Download.upload_date.isnot(None),
+            Download.file_exists == True,
+            Download.deleted_at.is_(None)
         ).all()
         assert len(dated_videos) == 10, "All videos with upload_dates should be kept"
 
@@ -724,12 +734,14 @@ class TestCleanupOldVideos:
         # Run cleanup - should handle missing files gracefully
         deleted_count = await cleanup_old_videos(channel, db_session)
 
-        # Database records should still be deleted
+        # Database records should still be soft-deleted
         assert deleted_count == 3
 
-        # Verify correct count remains
+        # Verify correct count of active videos remains (soft-delete keeps rows)
         remaining_count = db_session.query(Download).filter(
-            Download.channel_id == channel.id
+            Download.channel_id == channel.id,
+            Download.file_exists == True,
+            Download.deleted_at.is_(None)
         ).count()
         assert remaining_count == 5
 
@@ -777,11 +789,13 @@ class TestCleanupOldVideos:
         # Run cleanup - should continue despite error
         deleted_count = await cleanup_old_videos(channel, db_session)
 
-        # All database records should be deleted (even if file deletion failed)
+        # All database records should be soft-deleted (even if file deletion failed)
         assert deleted_count == 3
 
         remaining_count = db_session.query(Download).filter(
-            Download.channel_id == channel.id
+            Download.channel_id == channel.id,
+            Download.file_exists == True,
+            Download.deleted_at.is_(None)
         ).count()
         assert remaining_count == 5
 

--- a/frontend/src/__tests__/components/ChannelsList.test.tsx
+++ b/frontend/src/__tests__/components/ChannelsList.test.tsx
@@ -110,11 +110,12 @@ describe('ChannelsList Component', () => {
         />
       )
 
-      // Find the channel container divs (they don't have role="button" anymore)
-      const channelContainers = screen.getByText('Mrs. Rachel - Toddler Learning Videos').closest('div')
-      
+      // The channel name is nested inside inner layout divs; the selection
+      // classes live on the clickable row container (cursor-pointer)
+      const channelRow = screen.getByText('Mrs. Rachel - Toddler Learning Videos').closest('div.cursor-pointer')
+
       // Selected channel should have red border styling
-      expect(channelContainers).toHaveClass('border-red-500', 'bg-red-50')
+      expect(channelRow).toHaveClass('border-red-500', 'bg-red-50')
     })
   })
 
@@ -146,9 +147,9 @@ describe('ChannelsList Component', () => {
         />
       )
 
-      // Find and click remove button for first channel
-      const removeButtons = screen.getAllByTitle('Remove channel')
-      fireEvent.click(removeButtons[0])
+      // Delete now lives in the kebab menu: open it, then click the item
+      fireEvent.click(screen.getAllByTitle('More actions')[0])
+      fireEvent.click(screen.getByRole('button', { name: /delete channel/i }))
 
       // Should show confirmation modal instead of immediately deleting
       expect(screen.getByText('Confirm Channel Deletion')).toBeInTheDocument()
@@ -389,10 +390,12 @@ describe('ChannelsList Component', () => {
       await user.type(input, '5')
       await user.type(input, '{Enter}')
 
-      // Should show confirmation dialog
+      // Should show confirmation dialog. The from/to numbers are wrapped in
+      // <strong> tags, so match on the dialog's combined text content.
       await waitFor(() => {
         expect(screen.getByText('Confirm Limit Reduction')).toBeInTheDocument()
-        expect(screen.getByText(/reducing the video limit from 25 to 5/i)).toBeInTheDocument()
+        const dialog = screen.getByText('Confirm Limit Reduction').closest('div')
+        expect(dialog).toHaveTextContent(/reducing the video limit from 25 to 5/i)
       })
     })
 
@@ -480,6 +483,49 @@ describe('ChannelsList Component', () => {
     })
   })
 
+  // Row actions moved into a kebab menu ("More actions") — open it first,
+  // then click the labeled menu item
+  const clickKebabMenuItem = (itemName: RegExp, rowIndex = 0) => {
+    fireEvent.click(screen.getAllByTitle('More actions')[rowIndex])
+    fireEvent.click(screen.getByRole('button', { name: itemName }))
+  }
+
+  describe('Quality Preset (US-015)', () => {
+    it('updates channel quality via the kebab menu select', async () => {
+      ;(fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 1, quality_preset: '720p' }),
+      })
+
+      render(
+        <ChannelsList
+          channels={sampleChannels}
+          selectedChannelId={null}
+          onSelectChannel={mockOnSelectChannel}
+          onRemoveChannel={mockOnRemoveChannel}
+          onUpdateChannel={mockOnUpdateChannel}
+        />
+      )
+
+      // Open the kebab menu and change the quality select
+      fireEvent.click(screen.getAllByTitle('More actions')[0])
+      const select = screen.getByLabelText(/video quality for/i)
+      fireEvent.change(select, { target: { value: '720p' } })
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith('/api/v1/channels/1', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ quality_preset: '720p' }),
+        })
+      })
+
+      await waitFor(() => {
+        expect(mockOnUpdateChannel).toHaveBeenCalledWith(1, { quality_preset: '720p' })
+      })
+    })
+  })
+
   describe('Delete Modal Functionality', () => {
     it('shows delete modal when delete button clicked', async () => {
       render(
@@ -491,8 +537,7 @@ describe('ChannelsList Component', () => {
         />
       )
 
-      const deleteButton = screen.getAllByTitle('Remove channel')[0]
-      fireEvent.click(deleteButton)
+      clickKebabMenuItem(/delete channel/i)
 
       expect(screen.getByText('Confirm Channel Deletion')).toBeInTheDocument()
       expect(screen.getByText('Also delete media files (permanent)')).toBeInTheDocument()
@@ -513,7 +558,7 @@ describe('ChannelsList Component', () => {
         />
       )
 
-      fireEvent.click(screen.getAllByTitle('Remove channel')[0])
+      clickKebabMenuItem(/delete channel/i)
       fireEvent.click(screen.getByText('Delete Channel'))
 
       await waitFor(() => {
@@ -543,7 +588,7 @@ describe('ChannelsList Component', () => {
         />
       )
 
-      fireEvent.click(screen.getAllByTitle('Remove channel')[0])
+      clickKebabMenuItem(/delete channel/i)
       fireEvent.click(screen.getByLabelText('Also delete media files (permanent)'))
       fireEvent.click(screen.getByText('Delete Channel'))
 
@@ -565,8 +610,8 @@ describe('ChannelsList Component', () => {
         />
       )
 
-      // Open modal
-      fireEvent.click(screen.getAllByTitle('Remove channel')[0])
+      // Open modal via the kebab menu
+      clickKebabMenuItem(/delete channel/i)
       expect(screen.getByText('Confirm Channel Deletion')).toBeInTheDocument()
 
       // Cancel
@@ -594,13 +639,12 @@ describe('ChannelsList Component', () => {
         />
       )
 
-      const reindexButton = screen.getAllByTitle('Reindex media (sync DB with disk)')[0]
-      fireEvent.click(reindexButton)
+      clickKebabMenuItem(/reindex media/i)
 
       await waitFor(() => {
         expect(fetch).toHaveBeenCalledWith(
           '/api/v1/channels/1/reindex',
-          expect.objectContaining({ 
+          expect.objectContaining({
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
           })
@@ -623,7 +667,7 @@ describe('ChannelsList Component', () => {
         />
       )
 
-      fireEvent.click(screen.getAllByTitle('Reindex media (sync DB with disk)')[0])
+      clickKebabMenuItem(/reindex media/i)
 
       await waitFor(() => {
         expect(screen.getByText('Reindex complete - found 2, added 3, missing 1')).toBeInTheDocument()
@@ -645,7 +689,7 @@ describe('ChannelsList Component', () => {
         />
       )
 
-      fireEvent.click(screen.getAllByTitle('Reindex media (sync DB with disk)')[0])
+      clickKebabMenuItem(/reindex media/i)
 
       await waitFor(() => {
         expect(screen.getByText('Reindex failed')).toBeInTheDocument()
@@ -670,16 +714,17 @@ describe('ChannelsList Component', () => {
         />
       )
 
-      const reindexButton = screen.getAllByTitle('Reindex media (sync DB with disk)')[0]
-      fireEvent.click(reindexButton)
+      // Trigger reindex via the kebab menu (the menu closes on click)
+      clickKebabMenuItem(/reindex media/i)
 
-      // Should show loading state (button disabled and spinning icon)
-      expect(reindexButton).toBeDisabled()
-      
+      // Re-open the menu: while the operation runs, the reindex item is disabled
+      fireEvent.click(screen.getAllByTitle('More actions')[0])
+      expect(screen.getByRole('button', { name: /reindex media/i })).toBeDisabled()
+
       // Wait for operation to complete
       await waitFor(() => {
-        expect(reindexButton).not.toBeDisabled()
-      }, { timeout: 200 })
+        expect(screen.getByRole('button', { name: /reindex media/i })).not.toBeDisabled()
+      }, { timeout: 300 })
     })
   })
 })

--- a/frontend/src/__tests__/components/YouTubeDownloader.test.tsx
+++ b/frontend/src/__tests__/components/YouTubeDownloader.test.tsx
@@ -17,29 +17,42 @@ import { YouTubeDownloader } from '../../components/YouTubeDownloader'
 // Mock fetch globally for API testing
 global.fetch = jest.fn()
 
+// Stub out SchedulerStatusWidget: it fires its own fetches on mount
+// (/scheduler/status, /channels) which would consume the ordered fetch
+// mocks below and break every assertion that depends on call order.
+jest.mock('../../components/SchedulerStatusWidget', () => ({
+  SchedulerStatusWidget: () => null,
+}))
+
+const jsonResponse = (body: unknown, ok = true) => ({ ok, json: () => Promise.resolve(body) })
+
+// Responses for POST /api/v1/channels, consumed in order. Tests push what
+// they need. URL-dispatched mocking (instead of ordered mockResolvedValueOnce
+// chains) keeps tests immune to changes in how many fetches mount performs.
+let postChannelResponses: unknown[] = []
+
 describe('YouTubeDownloader Component - Story 1 Tests', () => {
   beforeEach(() => {
-    // Clear all mocks before each test
     jest.clearAllMocks()
-    ;(fetch as jest.Mock).mockClear()
-    
-    // Mock the default API calls that occur on component mount
-    ;(fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        // Health check
-        ok: true,
-        json: () => Promise.resolve({ status: 'healthy' })
-      })
-      .mockResolvedValueOnce({
-        // Existing channels list (empty by default)
-        ok: true,
-        json: () => Promise.resolve({ channels: [], total: 0, enabled: 0 })
-      })
-      .mockResolvedValueOnce({
-        // Default video limit setting
-        ok: true,
-        json: () => Promise.resolve({ limit: 10 })
-      })
+    postChannelResponses = []
+    ;(fetch as jest.Mock).mockReset()
+    ;(fetch as jest.Mock).mockImplementation((url: string, options?: RequestInit) => {
+      if (url === '/api/health') {
+        return Promise.resolve(jsonResponse({ status: 'healthy' }))
+      }
+      if (url === '/api/v1/settings/default-video-limit') {
+        return Promise.resolve(jsonResponse({ limit: 10 }))
+      }
+      if (url === '/api/v1/channels' && options?.method === 'POST') {
+        const next = postChannelResponses.shift()
+        if (next instanceof Promise) return next
+        return Promise.resolve(next ?? jsonResponse({ detail: 'No mocked POST response queued' }, false))
+      }
+      if (url === '/api/v1/channels') {
+        return Promise.resolve(jsonResponse({ channels: [], total: 0, enabled: 0 }))
+      }
+      return Promise.resolve(jsonResponse({}))
+    })
   })
 
   describe('Form Rendering - Story 1 Requirements', () => {
@@ -79,32 +92,16 @@ describe('YouTubeDownloader Component - Story 1 Tests', () => {
       const user = userEvent.setup()
       
       // Mock successful channel creation
-      ;(fetch as jest.Mock)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'healthy' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ channels: [], total: 0 })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ limit: 10 })
-        })
-        .mockResolvedValueOnce({
-          // Channel creation success
-          ok: true,
-          json: () => Promise.resolve({
-            id: 1,
-            url: 'https://www.youtube.com/@MrsRachel',
-            name: 'Mrs. Rachel - Toddler Learning Videos',
-            limit: 10,
-            enabled: true,
-            created_at: '2024-01-01T00:00:00Z',
-            updated_at: '2024-01-01T00:00:00Z'
-          })
-        })
+      postChannelResponses.push(jsonResponse({
+        id: 1,
+        url: 'https://www.youtube.com/@MrsRachel',
+        name: 'Mrs. Rachel - Toddler Learning Videos',
+        limit: 10,
+        enabled: true,
+        metadata_status: 'completed',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      }))
 
       render(<YouTubeDownloader />)
 
@@ -130,7 +127,9 @@ describe('YouTubeDownloader Component - Story 1 Tests', () => {
         expect(screen.getByText(/successfully added channel/i)).toBeInTheDocument()
       }, { timeout: 3000 })
 
-      // Verify API call was made correctly
+      // Verify API call was made correctly. quality_preset is intentionally
+      // omitted so the backend applies the global default quality (US-015),
+      // and no limit field means the default video limit applies (US-003)
       expect(fetch).toHaveBeenCalledWith('/api/v1/channels', {
         method: 'POST',
         headers: {
@@ -138,9 +137,7 @@ describe('YouTubeDownloader Component - Story 1 Tests', () => {
         },
         body: JSON.stringify({
           url: 'https://www.youtube.com/@MrsRachel',
-          enabled: true,
-          quality_preset: 'best'
-          // No limit field - should use default
+          enabled: true
         }),
       })
 
@@ -156,31 +153,16 @@ describe('YouTubeDownloader Component - Story 1 Tests', () => {
     it('displays channel information in card format', async () => {
       const user = userEvent.setup()
       
-      ;(fetch as jest.Mock)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'healthy' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ channels: [], total: 0 })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ limit: 10 })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({
-            id: 1,
-            name: 'Test Channel',
-            url: 'https://www.youtube.com/@TestChannel',
-            limit: 10,
-            enabled: true,
-            created_at: '2024-01-01T00:00:00Z',
-            updated_at: '2024-01-01T00:00:00Z'
-          })
-        })
+      postChannelResponses.push(jsonResponse({
+        id: 1,
+        name: 'Test Channel',
+        url: 'https://www.youtube.com/@TestChannel',
+        limit: 10,
+        enabled: true,
+        metadata_status: 'completed',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      }))
 
       render(<YouTubeDownloader />)
 
@@ -281,45 +263,28 @@ describe('YouTubeDownloader Component - Story 1 Tests', () => {
       const user = userEvent.setup()
       
       // Mock responses for multiple channel additions
-      ;(fetch as jest.Mock)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'healthy' })
+      postChannelResponses.push(
+        jsonResponse({
+          id: 1,
+          name: 'First Channel',
+          url: 'https://www.youtube.com/@FirstChannel',
+          limit: 10,
+          enabled: true,
+          metadata_status: 'completed',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z'
+        }),
+        jsonResponse({
+          id: 2,
+          name: 'Second Channel',
+          url: 'https://www.youtube.com/@SecondChannel',
+          limit: 10,
+          enabled: true,
+          metadata_status: 'completed',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z'
         })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ channels: [], total: 0 })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ limit: 10 })
-        })
-        .mockResolvedValueOnce({
-          // First channel addition
-          ok: true,
-          json: () => Promise.resolve({
-            id: 1,
-            name: 'First Channel',
-            url: 'https://www.youtube.com/@FirstChannel',
-            limit: 10,
-            enabled: true,
-            created_at: '2024-01-01T00:00:00Z',
-            updated_at: '2024-01-01T00:00:00Z'
-          })
-        })
-        .mockResolvedValueOnce({
-          // Second channel addition
-          ok: true,
-          json: () => Promise.resolve({
-            id: 2,
-            name: 'Second Channel',
-            url: 'https://www.youtube.com/@SecondChannel',
-            limit: 10,
-            enabled: true,
-            created_at: '2024-01-01T00:00:00Z',
-            updated_at: '2024-01-01T00:00:00Z'
-          })
-        })
+      )
 
       render(<YouTubeDownloader />)
 
@@ -369,31 +334,19 @@ describe('YouTubeDownloader Component - Story 1 Tests', () => {
         resolveChannelCreation = resolve
       })
 
-      ;(fetch as jest.Mock)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'healthy' })
+      postChannelResponses.push(slowPromise.then(() => ({
+        ok: true,
+        json: () => Promise.resolve({
+          id: 1,
+          name: 'Test Channel',
+          url: 'https://www.youtube.com/@TestChannel',
+          limit: 10,
+          enabled: true,
+          metadata_status: 'completed',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z'
         })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ channels: [], total: 0 })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ limit: 10 })
-        })
-        .mockReturnValueOnce(slowPromise.then(() => ({
-          ok: true,
-          json: () => Promise.resolve({
-            id: 1,
-            name: 'Test Channel',
-            url: 'https://www.youtube.com/@TestChannel',
-            limit: 10,
-            enabled: true,
-            created_at: '2024-01-01T00:00:00Z',
-            updated_at: '2024-01-01T00:00:00Z'
-          })
-        })))
+      })))
 
       render(<YouTubeDownloader />)
 
@@ -424,24 +377,8 @@ describe('YouTubeDownloader Component - Story 1 Tests', () => {
     it('handles API errors gracefully', async () => {
       const user = userEvent.setup()
       
-      ;(fetch as jest.Mock)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'healthy' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ channels: [], total: 0 })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ limit: 10 })
-        })
-        .mockResolvedValueOnce({
-          // API error response
-          ok: false,
-          json: () => Promise.resolve({ detail: 'Channel not found' })
-        })
+      // API error response for the POST
+      postChannelResponses.push(jsonResponse({ detail: 'Channel not found' }, false))
 
       render(<YouTubeDownloader />)
 

--- a/frontend/src/components/ChannelsList.tsx
+++ b/frontend/src/components/ChannelsList.tsx
@@ -32,7 +32,9 @@ import { ScheduleOverrideModal } from './ScheduleOverrideModal'
  * - Maintains edit state isolation per channel
  */
 
-interface Channel {
+// Exported as the single source of truth for the channel shape — imported by
+// YouTubeDownloader to avoid divergent duplicate interfaces (TS2719)
+export interface Channel {
   id: number
   url: string
   name: string
@@ -42,6 +44,7 @@ interface Channel {
   updated_at: string
   metadata_status: string
   schedule_override?: string | null
+  quality_preset?: string
   metadata_path?: string
   directory_path?: string
   last_metadata_update?: string
@@ -69,7 +72,10 @@ export function ChannelsList({
   const [editingChannelId, setEditingChannelId] = useState<number | null>(null)
   
   // Current value in the edit input field (may differ from saved value during editing)
-  const [editingLimit, setEditingLimit] = useState<number>(10)
+  // number | '' so the field can be transiently empty while the user retypes
+  // (parseInt-with-fallback previously snapped '' to 1, making e.g. "15"
+  // impossible to type after clearing — it became "115")
+  const [editingLimit, setEditingLimit] = useState<number | ''>(10)
   
   // Original limit value before editing started (used for reset/cancel and confirmation logic)
   const [originalLimit, setOriginalLimit] = useState<number>(10)
@@ -120,6 +126,34 @@ export function ChannelsList({
   // === CUSTOM SCHEDULE MODAL STATE (US-016) ===
   // Channel whose custom schedule is being edited (null = modal closed)
   const [scheduleModalChannel, setScheduleModalChannel] = useState<Channel | null>(null)
+
+  // === QUALITY PRESET STATE (US-015) ===
+  // Channel whose quality is currently being saved (disables its select)
+  const [updatingQualityChannelId, setUpdatingQualityChannelId] = useState<number | null>(null)
+
+  /**
+   * Update a channel's video quality preset (US-015).
+   * Takes effect on the channel's next download cycle.
+   */
+  const updateQualityPreset = async (channelId: number, quality: string) => {
+    setUpdatingQualityChannelId(channelId)
+    try {
+      const response = await fetch(`/api/v1/channels/${channelId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ quality_preset: quality }),
+      })
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.detail || 'Failed to update video quality')
+      }
+      onUpdateChannel?.(channelId, { quality_preset: quality })
+    } catch (err) {
+      setRefreshError(err instanceof Error ? err.message : 'Failed to update video quality')
+    } finally {
+      setUpdatingQualityChannelId(null)
+    }
+  }
   const [isDeleting, setIsDeleting] = useState(false)
   const [deleteSuccess, setDeleteSuccess] = useState('')
 
@@ -249,8 +283,8 @@ export function ChannelsList({
     if (e) e.stopPropagation() // Prevent event bubbling if called from button click
     
     // === INPUT VALIDATION ===
-    // Frontend validation to catch invalid ranges before API call
-    if (editingLimit < 1 || editingLimit > 100) {
+    // Frontend validation to catch empty/invalid ranges before API call
+    if (editingLimit === '' || editingLimit < 1 || editingLimit > 100) {
       setUpdateError('Limit must be between 1 and 100')
       return // Stop here - don't proceed with invalid values
     }
@@ -690,7 +724,7 @@ export function ChannelsList({
                         min="1"
                         max="100"
                         value={editingLimit}
-                        onChange={(e) => setEditingLimit(parseInt(e.target.value) || 1)}
+                        onChange={(e) => setEditingLimit(e.target.value === '' ? '' : parseInt(e.target.value))}
                         onKeyDown={(e) => handleKeyPress(e, channel.id)}                // Enter/Escape shortcuts
                         onFocus={(e) => e.target.select()}                             // Fallback text selection
                         className="w-16 px-2 py-1 text-xs border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:outline-none"
@@ -800,6 +834,27 @@ export function ChannelsList({
                             <DownloadIcon className={`h-4 w-4 mr-2 ${downloadingChannelId === channel.id ? 'animate-pulse' : ''}`} />
                             Download recent videos
                           </button>
+
+                          {/* Video quality (US-015) */}
+                          <div
+                            className="px-4 py-2 flex items-center justify-between"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <span className="text-sm text-gray-700">Quality</span>
+                            <select
+                              value={channel.quality_preset || 'best'}
+                              disabled={updatingQualityChannelId === channel.id}
+                              aria-label={`Video quality for ${channel.name}`}
+                              onChange={(e) => updateQualityPreset(channel.id, e.target.value)}
+                              className="ml-2 rounded border border-gray-300 px-1.5 py-0.5 text-xs focus:border-red-500 focus:ring-red-500 disabled:opacity-50"
+                            >
+                              <option value="best">Best</option>
+                              <option value="2160p">2160p</option>
+                              <option value="1080p">1080p</option>
+                              <option value="720p">720p</option>
+                              <option value="480p">480p</option>
+                            </select>
+                          </div>
 
                           {/* Custom schedule (US-016) */}
                           <button

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -81,6 +81,11 @@ export function Settings() {
   const [success, setSuccess] = useState<string>('')
   const [lastUpdated, setLastUpdated] = useState<string>('')
 
+  // Default quality preset state (US-015)
+  const [defaultQuality, setDefaultQuality] = useState<string>('best')
+  const [originalQuality, setOriginalQuality] = useState<string>('best')
+  const [qualitySaving, setQualitySaving] = useState<boolean>(false)
+
   // Scheduler state (Story 007)
   const [schedulerStatus, setSchedulerStatus] = useState<SchedulerStatus | null>(null)
   const [cronExpression, setCronExpression] = useState<string>('0 0 * * *')
@@ -151,6 +156,56 @@ export function Settings() {
       setError(errorMessage)
     } finally {
       setLoading(false)
+    }
+  }
+
+  /**
+   * Fetch the default video quality preset (US-015).
+   * Non-critical: failures leave the select at 'best' without blocking the page.
+   */
+  const fetchDefaultQuality = async () => {
+    try {
+      const response = await fetch('/api/v1/settings/default-quality')
+      if (response.ok) {
+        const data = await response.json()
+        setDefaultQuality(data.quality)
+        setOriginalQuality(data.quality)
+      }
+    } catch (err) {
+      console.error('Error fetching default quality:', err)
+    }
+  }
+
+  /**
+   * Save the default video quality preset (US-015).
+   * Applies to new channels only; existing channels keep their setting.
+   */
+  const saveDefaultQuality = async () => {
+    try {
+      setQualitySaving(true)
+      setError('')
+      setSuccess('')
+
+      const response = await fetch('/api/v1/settings/default-quality', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ quality: defaultQuality }),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.detail || 'Failed to update default quality')
+      }
+
+      const data = await response.json()
+      setOriginalQuality(data.quality)
+      setSuccess(`Default video quality updated to ${data.quality}`)
+      setTimeout(() => setSuccess(''), 3000)
+    } catch (err) {
+      console.error('Error saving default quality:', err)
+      setError(err instanceof Error ? err.message : 'Failed to save default quality')
+    } finally {
+      setQualitySaving(false)
     }
   }
 
@@ -522,6 +577,7 @@ export function Settings() {
   useEffect(() => {
     Promise.all([
       fetchDefaultLimit(),
+      fetchDefaultQuality(),
       fetchSchedulerStatus(),
       checkChannelsExist(),
       fetchNfoSettings()
@@ -629,6 +685,51 @@ export function Settings() {
               className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {saving ? (
+                <>
+                  <div className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full mr-2"></div>
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <Save className="h-4 w-4 mr-2" />
+                  Save
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Default Video Quality Setting (US-015) */}
+        <div>
+          <label htmlFor="defaultQuality" className="block text-sm font-medium text-gray-700 mb-2">
+            Default Video Quality
+          </label>
+          <div className="flex items-start space-x-4">
+            <div className="flex-1">
+              <select
+                id="defaultQuality"
+                value={defaultQuality}
+                onChange={(e) => setDefaultQuality(e.target.value)}
+                disabled={qualitySaving}
+                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              >
+                <option value="best">Best available</option>
+                <option value="2160p">2160p (4K)</option>
+                <option value="1080p">1080p</option>
+                <option value="720p">720p</option>
+                <option value="480p">480p</option>
+              </select>
+              <p className="mt-1 text-sm text-gray-500">
+                Quality preset applied to new channels. Downloads fall back to the best
+                available quality when the preferred one doesn&apos;t exist.
+              </p>
+            </div>
+            <button
+              onClick={saveDefaultQuality}
+              disabled={defaultQuality === originalQuality || qualitySaving}
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {qualitySaving ? (
                 <>
                   <div className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full mr-2"></div>
                   Saving...

--- a/frontend/src/components/YouTubeDownloader.tsx
+++ b/frontend/src/components/YouTubeDownloader.tsx
@@ -4,21 +4,8 @@ import {
   PlusIcon,
 } from 'lucide-react'
 import { DownloadResults } from './DownloadResults'
-import { ChannelsList } from './ChannelsList'
+import { ChannelsList, Channel } from './ChannelsList'
 import { SchedulerStatusWidget } from './SchedulerStatusWidget'
-
-/**
- * Channel interface representing a YouTube channel configuration
- */
-interface Channel {
-  id: number
-  url: string
-  name: string
-  limit: number
-  enabled: boolean
-  created_at: string
-  updated_at: string
-}
 
 /**
  * Props for YouTubeDownloader component
@@ -180,10 +167,11 @@ export function YouTubeDownloader({ onNavigateToSettings }: YouTubeDownloaderPro
     try {
       // Call backend API to add channel
       // User Story 3 Integration: Only send custom limit, let backend apply default
+      // US-015: quality_preset is omitted so the backend applies the global
+      // default quality setting (sending 'best' here would override it)
       const requestBody: any = {
         url: channelUrl,
-        enabled: true,
-        quality_preset: 'best'
+        enabled: true
       }
       
       // Only include limit if user explicitly chose a custom value

--- a/frontend/src/pages/api/v1/settings/default-quality.ts
+++ b/frontend/src/pages/api/v1/settings/default-quality.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { fetchBackend, formatApiError } from '@/lib/apiClient'
+
+/**
+ * API route proxy for the default video quality preset setting (US-015).
+ *
+ * GET returns the current default; PUT updates it. Applies to new channels
+ * only — existing channels keep their per-channel quality_preset.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET' && req.method !== 'PUT') {
+    res.setHeader('Allow', ['GET', 'PUT'])
+    return res.status(405).json({ error: `Method ${req.method} not allowed` })
+  }
+
+  try {
+    const { status, data } = await fetchBackend('/api/v1/settings/default-quality', {
+      method: req.method,
+      body: req.method === 'PUT' ? req.body : undefined,
+      operationType: 'standard',
+    })
+
+    res.status(status).json(data)
+  } catch (error) {
+    const errorResponse = formatApiError(error, 'Default quality setting')
+    res.status(errorResponse.timedOut ? 504 : 500).json(errorResponse)
+  }
+}


### PR DESCRIPTION
## Summary

Two things: **US-015 (Download Quality Configuration) delivered end-to-end**, and **the entire test suite repaired** — every one of the 28 long-standing pre-existing failures plus the TypeScript error is fixed. Also unblocks the event loop in the remaining blocking async endpoints.

### US-015: quality presets now real

`quality_preset` was stored, synced, and validated — but the downloader always used a hardcoded format string. Now:

- Preset → yt-dlp format mapping (`best`/`2160p`/`1080p`/`720p`/`480p`) with graceful fallback chains, so downloads degrade to best-available when the preferred quality doesn't exist; unknown presets fall back to `best` with a warning
- `download_video` applies the channel's preset per download
- Channel create/update validate presets (422 on unknown values)
- New `default_quality_preset` setting (GET/PUT `/settings/default-quality`, YAML-synced) applied to new channels; the add-channel form no longer hardcodes `best` so the default actually takes effect
- UI: per-channel quality select in the ChannelsList kebab menu + Default Video Quality select in Settings

### Event-loop unblocking (continuation of the #41 fix)

- Channel create (metadata extraction, image downloads, initial video downloads) and manual download trigger now run blocking yt-dlp work via `asyncio.to_thread`
- Refresh-metadata and reindex become sync handlers (threadpool)

### Test-suite repair — two real code bugs found

- **Limit editor input bug:** `parseInt(value) || 1` snapped an emptied field back to 1, so typing "15" after clearing produced "115" — real users could never retype a limit. Now allows a transient empty value, validated on save. This alone fixed 4 failing tests.
- **TS2719:** duplicate divergent `Channel` interfaces in YouTubeDownloader vs ChannelsList; ChannelsList now exports the single source of truth.
- **Stale tests updated** for: soft-delete cleanup semantics (4), the `_find_video_file_path` disk-check path (1), service-side metadata status transitions + request-scoped sessions + TestClient exception behavior (3), the kebab-menu UI redesign (10), and fragile ordered fetch mocks replaced with URL-dispatched mocking with `SchedulerStatusWidget` stubbed (5).
- Adds the `OSError` disk-degradation test for the dashboard requested in #40's review.

## Testing

- **Backend: 331 passed, 0 failed** — first fully green backend run (was 8 failing since before this session).
- **Frontend: 71 passed, 0 failed** — was 20 failing.
- **tsc: 0 errors** — was 1.
- 14 new quality-preset tests (format mapping/fallbacks, download opts use the channel preset, validation, default-quality endpoints) + 1 kebab quality-select test.

https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd)_