### PR TITLE
feat: live download progress (US-010), operational hardening, datetime migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,26 @@ ChannelFinWatcher periodically monitors YouTube channels and downloads only the 
 
 - **Recent Videos Only**: Downloads last X videos per channel, not entire history
 - **Smart Content Filtering**: Automatically excludes YouTube Shorts and live streams, downloading only regular uploaded videos
-- **Real-time Updates**: Live progress tracking via WebSocket connections
+- **Live Download Progress**: Real-time progress bars on the dashboard (polling), plus a Server-Sent Events stream for API consumers
 - **Auto-cleanup**: Removes older videos when limits are exceeded
+- **Automatic Retry**: Transient download failures retry with backoff; permanently failing videos stop after 5 attempts and can be retried manually from the History view
+- **Quality Presets**: Per-channel video quality (best/2160p/1080p/720p/480p) with graceful fallback, plus a global default for new channels
+- **Flexible Scheduling**: Global cron schedule plus optional per-channel schedule overrides with live cron validation
+- **Status Dashboard**: Channel health cards, storage capacity gauge with 80% warnings, and library totals
+- **Download History**: Cross-channel history with filtering, pagination, and one-click retry of failures
+- **Failure Notifications**: Optional [Apprise](https://github.com/caronc/apprise) notifications (Discord, ntfy, Telegram, email, ...) when scheduled runs fail
+- **Deep Health Checks**: `/health` verifies database, yt-dlp, ffmpeg, disk capacity, and scheduler liveness
 - **Dual Configuration**: Manage channels via YAML config or web interface
 - **Channel Control**: Enable/disable channels without removal
-- **Storage Monitoring**: Track disk usage and system health
-- **Jellyfin Compatible**: Maintains proper file organization and metadata
+- **Jellyfin Compatible**: Maintains proper file organization and NFO metadata
 - **Docker Development**: 100% containerized development environment
+
+## Web Interface
+
+- **Dashboard** — channel status cards (health, video count vs limit, storage, last check), live download progress, storage overview, scheduler status
+- **Channels** — add channels, edit limits inline, set per-channel quality and custom cron schedules, refresh metadata, reindex media, regenerate NFO files
+- **History** — every download across all channels with status/channel filters and retry buttons on failures
+- **Settings** — default video limit and quality, global schedule with cron validation, NFO options, cookie file health, and failure notifications
 
 ## Quick Start (Docker Development)
 

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -1371,6 +1371,24 @@ async def get_active_downloads():
     return {"active": active, "count": len(active)}
 
 
+async def _progress_event_stream(request: Request):
+    """SSE event generator: one JSON snapshot per second until disconnect.
+
+    Module-level (not a closure) so tests can drive it directly with a fake
+    request — TestClient cannot cleanly disconnect an infinite stream.
+    """
+    import json
+    from app.progress_store import download_progress_store
+
+    while True:
+        if await request.is_disconnected():
+            break
+        active = download_progress_store.snapshot()
+        payload = json.dumps({"active": active, "count": len(active)})
+        yield f"data: {payload}\n\n"
+        await asyncio.sleep(1)
+
+
 @router.get("/downloads/progress/stream")
 async def stream_download_progress(request: Request):
     """
@@ -1385,20 +1403,8 @@ async def stream_download_progress(request: Request):
         GET /api/v1/downloads/progress/stream
         data: {"active": [...], "count": 1}
     """
-    import json
-    from app.progress_store import download_progress_store
-
-    async def event_stream():
-        while True:
-            if await request.is_disconnected():
-                break
-            active = download_progress_store.snapshot()
-            payload = json.dumps({"active": active, "count": len(active)})
-            yield f"data: {payload}\n\n"
-            await asyncio.sleep(1)
-
     return StreamingResponse(
-        event_stream(),
+        _progress_event_stream(request),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -5,7 +5,6 @@ import glob
 import shutil
 import asyncio
 import logging
-from datetime import datetime
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
@@ -22,6 +21,7 @@ from app.metadata_service import metadata_service
 from app.video_download_service import video_download_service
 from app.scheduled_download_job import cleanup_old_videos
 from app.utils import update_channel_in_yaml, remove_channel_from_yaml, sync_setting_to_yaml, get_default_video_limit as get_default_limit_setting, get_default_quality_preset, channel_dir_name
+from app.time_utils import utc_now, utc_from_timestamp
 from app.schemas import (
     Channel as ChannelSchema,
     ChannelCreate,
@@ -543,7 +543,7 @@ def _reindex_channel_media(channel: Channel, settings, db: Session) -> dict:
                                         status='completed',
                                         file_exists=True,
                                         file_path=video_file_path,
-                                        completed_at=datetime.utcnow()
+                                        completed_at=utc_now()
                                     )
                                     db.add(download)
                                     stats["added"] += 1
@@ -788,9 +788,8 @@ async def update_default_video_limit(
             )
         
         # Update the setting value and timestamp
-        from datetime import datetime
         setting.value = str(setting_update.limit)
-        setting.updated_at = datetime.utcnow()
+        setting.updated_at = utc_now()
         
         # Commit to database
         db.commit()
@@ -875,14 +874,14 @@ async def update_default_quality(
 
         if setting:
             setting.value = setting_update.quality
-            setting.updated_at = datetime.utcnow()
+            setting.updated_at = utc_now()
         else:
             setting = ApplicationSettings(
                 key='default_quality_preset',
                 value=setting_update.quality,
                 description='Default video quality preset for new channels',
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=utc_now(),
+                updated_at=utc_now(),
             )
             db.add(setting)
 
@@ -933,8 +932,8 @@ async def get_cookies_status():
                 "modified_at": None, "age_days": None, "stale": False}
 
     stat = os.stat(path)
-    modified = datetime.utcfromtimestamp(stat.st_mtime)
-    age_days = (datetime.utcnow() - modified).days
+    modified = utc_from_timestamp(stat.st_mtime)
+    age_days = (utc_now() - modified).days
     return {
         "present": True,
         "path": path,
@@ -989,14 +988,14 @@ async def update_notification_settings(
     ).first()
     if setting:
         setting.value = url
-        setting.updated_at = datetime.utcnow()
+        setting.updated_at = utc_now()
     else:
         setting = ApplicationSettings(
             key=NOTIFICATION_URL_KEY,
             value=url,
             description="Apprise URL for failure notifications (blank = disabled)",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=utc_now(),
+            updated_at=utc_now(),
         )
         db.add(setting)
     db.commit()
@@ -1349,7 +1348,7 @@ async def get_dashboard(db: Session = Depends(get_db)):
             storage_bytes=total_storage,
         ),
         channels=items,
-        generated_at=datetime.utcnow(),
+        generated_at=utc_now(),
     )
 
 
@@ -1705,14 +1704,14 @@ async def update_scheduler_schedule(
 
     if cron_setting:
         cron_setting.value = cron_expr
-        cron_setting.updated_at = datetime.utcnow()
+        cron_setting.updated_at = utc_now()
     else:
         cron_setting = ApplicationSettings(
             key="cron_schedule",
             value=cron_expr,
             description="Cron expression for automatic downloads",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db.add(cron_setting)
 
@@ -1767,14 +1766,14 @@ async def toggle_scheduler(
 
     if enabled_setting:
         enabled_setting.value = new_value
-        enabled_setting.updated_at = datetime.utcnow()
+        enabled_setting.updated_at = utc_now()
     else:
         enabled_setting = ApplicationSettings(
             key="scheduler_enabled",
             value=new_value,
             description="Enable/disable automatic scheduled downloads",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db.add(enabled_setting)
 
@@ -2070,7 +2069,6 @@ async def update_nfo_settings(
         }
     """
     try:
-        from datetime import datetime
 
         # Validate input
         if settings.enabled is None and settings.overwrite_existing is None:
@@ -2088,15 +2086,15 @@ async def update_nfo_settings(
 
             if enabled_setting:
                 enabled_setting.value = enabled_value
-                enabled_setting.updated_at = datetime.utcnow()
+                enabled_setting.updated_at = utc_now()
             else:
                 # Create if doesn't exist
                 enabled_setting = ApplicationSettings(
                     key='nfo_enabled',
                     value=enabled_value,
                     description='Enable/disable NFO file generation for new video downloads.',
-                    created_at=datetime.utcnow(),
-                    updated_at=datetime.utcnow()
+                    created_at=utc_now(),
+                    updated_at=utc_now()
                 )
                 db.add(enabled_setting)
 
@@ -2111,15 +2109,15 @@ async def update_nfo_settings(
 
             if overwrite_setting:
                 overwrite_setting.value = overwrite_value
-                overwrite_setting.updated_at = datetime.utcnow()
+                overwrite_setting.updated_at = utc_now()
             else:
                 # Create if doesn't exist
                 overwrite_setting = ApplicationSettings(
                     key='nfo_overwrite_existing',
                     value=overwrite_value,
                     description='Overwrite existing NFO files during regeneration.',
-                    created_at=datetime.utcnow(),
-                    updated_at=datetime.utcnow()
+                    created_at=utc_now(),
+                    updated_at=utc_now()
                 )
                 db.add(overwrite_setting)
 

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -39,6 +39,7 @@ from app.schemas import (
     RetryDownloadResponse,
     DownloadHistory as DownloadHistorySchema,
     NfoSettingsUpdate,
+    NotificationSettingsUpdate,
     DiskUsage,
     ChannelDashboardItem,
     DashboardTotals,
@@ -908,6 +909,146 @@ async def update_default_quality(
             status_code=500,
             detail="Internal server error while updating default quality preset"
         )
+
+
+@router.get("/settings/cookies-status", tags=["Settings"])
+async def get_cookies_status():
+    """
+    Report the state of the YouTube cookies file (operational hardening).
+
+    Cookies are the #1 operational breakage source (they expire silently and
+    downloads start failing with auth-shaped errors). Surfacing presence and
+    age lets the UI warn before that happens.
+
+    Example:
+        GET /api/v1/settings/cookies-status
+        Response: {"present": true, "size_bytes": 4096,
+                   "modified_at": "...", "age_days": 12, "stale": false}
+    """
+    settings = get_settings()
+    path = settings.cookies_file
+
+    if not os.path.exists(path):
+        return {"present": False, "path": path, "size_bytes": None,
+                "modified_at": None, "age_days": None, "stale": False}
+
+    stat = os.stat(path)
+    modified = datetime.utcfromtimestamp(stat.st_mtime)
+    age_days = (datetime.utcnow() - modified).days
+    return {
+        "present": True,
+        "path": path,
+        "size_bytes": stat.st_size,
+        "modified_at": modified.isoformat(),
+        "age_days": age_days,
+        # YouTube session cookies commonly rot within weeks
+        "stale": age_days >= 30,
+    }
+
+
+@router.get("/settings/notifications", tags=["Settings"])
+async def get_notification_settings(db: Session = Depends(get_db)):
+    """
+    Get the configured Apprise notification URL (blank = disabled).
+
+    The URL may embed credentials (tokens/webhooks), so it is returned
+    as-is only to this trusted single-user API — consistent with the
+    app's no-auth, trusted-LAN deployment model.
+    """
+    from app.notification_service import get_notification_url
+
+    url = get_notification_url(db)
+    return {"url": url or "", "enabled": bool(url)}
+
+
+@router.put("/settings/notifications", tags=["Settings"])
+async def update_notification_settings(
+    payload: NotificationSettingsUpdate,
+    db: Session = Depends(get_db)
+):
+    """
+    Set or clear the Apprise notification URL.
+
+    Blank URL disables notifications. Non-blank URLs are validated against
+    Apprise's URL parser (400 on unrecognized formats).
+
+    Example:
+        PUT /api/v1/settings/notifications
+        Body: {"url": "ntfy://ntfy.sh/my-topic"}
+    """
+    from app.notification_service import validate_notification_url, NOTIFICATION_URL_KEY
+
+    url = (payload.url or "").strip()
+    if url:
+        is_valid, error = validate_notification_url(url)
+        if not is_valid:
+            raise HTTPException(status_code=400, detail=error)
+
+    setting = db.query(ApplicationSettings).filter(
+        ApplicationSettings.key == NOTIFICATION_URL_KEY
+    ).first()
+    if setting:
+        setting.value = url
+        setting.updated_at = datetime.utcnow()
+    else:
+        setting = ApplicationSettings(
+            key=NOTIFICATION_URL_KEY,
+            value=url,
+            description="Apprise URL for failure notifications (blank = disabled)",
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+        db.add(setting)
+    db.commit()
+
+    logger.info(f"Notifications {'configured' if url else 'disabled'}")
+    return {"url": url, "enabled": bool(url)}
+
+
+@router.post("/settings/notifications/test", tags=["Settings"])
+def send_test_notification(db: Session = Depends(get_db)):
+    """
+    Send a test notification to the configured URL.
+
+    Sync handler on purpose: Apprise performs blocking network I/O, so
+    FastAPI runs this in the threadpool.
+    """
+    from app.notification_service import get_notification_url, send_notification
+
+    if not get_notification_url(db):
+        raise HTTPException(status_code=400, detail="No notification URL configured")
+
+    sent = send_notification(db, "ChannelFinWatcher test",
+                             "Notifications are working correctly.")
+    if not sent:
+        raise HTTPException(
+            status_code=502,
+            detail="Notification dispatch failed - check the URL and service logs"
+        )
+    return {"message": "Test notification sent"}
+
+
+@router.get("/logs/recent", tags=["System"])
+async def get_recent_logs(
+    limit: int = Query(100, ge=1, le=500, description="Maximum records to return"),
+    level: Optional[str] = Query(None, description="Minimum level (INFO, WARNING, ERROR)"),
+):
+    """
+    Get recent application log records from the in-memory buffer (US-014).
+
+    Complements (does not replace) docker logs: gives the web UI and API
+    consumers quick access to the last 500 records without host shell access.
+
+    Example:
+        GET /api/v1/logs/recent?limit=50&level=WARNING
+    """
+    from app.log_buffer import log_buffer_handler
+
+    if level and level.upper() not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+        raise HTTPException(status_code=400, detail=f"Unknown log level: {level}")
+
+    records = log_buffer_handler.recent(limit=limit, level=level)
+    return {"logs": records, "count": len(records)}
 
 
 # === DOWNLOAD ENDPOINTS (User Story 5) ===

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -7,7 +7,8 @@ import asyncio
 import logging
 from datetime import datetime
 from typing import List, Optional
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -1196,6 +1197,58 @@ async def get_dashboard(db: Session = Depends(get_db)):
         ),
         channels=items,
         generated_at=datetime.utcnow(),
+    )
+
+
+@router.get("/downloads/active")
+async def get_active_downloads():
+    """
+    Get all currently-active downloads with real-time progress (US-010).
+
+    Snapshot of the in-memory progress store fed by yt-dlp progress hooks.
+    Designed for lightweight polling from the UI; for push-based consumption
+    use /downloads/progress/stream (SSE).
+
+    Example:
+        GET /api/v1/downloads/active
+        Response: {"active": [{"video_id": "...", "percent": 42.3, ...}], "count": 1}
+    """
+    from app.progress_store import download_progress_store
+
+    active = download_progress_store.snapshot()
+    return {"active": active, "count": len(active)}
+
+
+@router.get("/downloads/progress/stream")
+async def stream_download_progress(request: Request):
+    """
+    Server-Sent Events stream of active download progress (US-010).
+
+    Emits a JSON snapshot of active downloads every second while the client
+    stays connected. Intended for direct API consumers; the bundled web UI
+    polls /downloads/active instead because the Next.js pages-router proxy
+    buffers streaming responses.
+
+    Example:
+        GET /api/v1/downloads/progress/stream
+        data: {"active": [...], "count": 1}
+    """
+    import json
+    from app.progress_store import download_progress_store
+
+    async def event_stream():
+        while True:
+            if await request.is_disconnected():
+                break
+            active = download_progress_store.snapshot()
+            payload = json.dumps({"active": active, "count": len(active)})
+            yield f"data: {payload}\n\n"
+            await asyncio.sleep(1)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -9,6 +9,9 @@ settings = get_settings()
 # timeout: how long a connection waits on a locked database before raising
 # "database is locked". Matters now that request handlers run blocking work
 # in threadpool threads and can genuinely overlap as concurrent writers.
+# check_same_thread=False: request-scoped sessions legally cross threads
+# (async handlers hand them to asyncio.to_thread workers), but each session
+# is only ever used by one thread at a time — sequential, never concurrent.
 engine = create_engine(
     settings.database_url,
     connect_args={"check_same_thread": False, "timeout": 15} if "sqlite" in settings.database_url else {}

--- a/backend/app/log_buffer.py
+++ b/backend/app/log_buffer.py
@@ -8,8 +8,8 @@ them without shell access to the host. Bounded deque = fixed memory cost.
 import logging
 import threading
 from collections import deque
-from datetime import datetime
 from typing import List, Optional
+from app.time_utils import utc_from_timestamp
 
 BUFFER_SIZE = 500
 
@@ -26,7 +26,7 @@ class RingBufferHandler(logging.Handler):
         try:
             with self._lock_buffer:
                 self._records.append({
-                    "timestamp": datetime.utcfromtimestamp(record.created).isoformat(),
+                    "timestamp": utc_from_timestamp(record.created).isoformat(),
                     "level": record.levelname,
                     "logger": record.name,
                     "message": record.getMessage(),

--- a/backend/app/log_buffer.py
+++ b/backend/app/log_buffer.py
@@ -37,6 +37,9 @@ class RingBufferHandler(logging.Handler):
 
     def recent(self, limit: int = 100, level: Optional[str] = None) -> List[dict]:
         """Most recent records, newest first, optionally filtered by min level."""
+        # Stdlib quirk: getLevelName() maps BOTH ways - given a level *name*
+        # ("WARNING") it returns the numeric level (30). Documented behavior,
+        # relied upon here and guarded by the isinstance check below.
         min_levelno = logging.getLevelName(level.upper()) if level else logging.NOTSET
         if not isinstance(min_levelno, int):
             min_levelno = logging.NOTSET

--- a/backend/app/log_buffer.py
+++ b/backend/app/log_buffer.py
@@ -1,0 +1,56 @@
+"""In-memory ring buffer of recent log records (US-014: logging access).
+
+Docker logs remain the primary troubleshooting channel; this buffer exposes
+the most recent records over the API so the web UI (or curl) can inspect
+them without shell access to the host. Bounded deque = fixed memory cost.
+"""
+
+import logging
+import threading
+from collections import deque
+from datetime import datetime
+from typing import List, Optional
+
+BUFFER_SIZE = 500
+
+
+class RingBufferHandler(logging.Handler):
+    """Logging handler that keeps the last BUFFER_SIZE records in memory."""
+
+    def __init__(self):
+        super().__init__()
+        self._lock_buffer = threading.Lock()
+        self._records = deque(maxlen=BUFFER_SIZE)
+
+    def emit(self, record: logging.LogRecord):
+        try:
+            with self._lock_buffer:
+                self._records.append({
+                    "timestamp": datetime.utcfromtimestamp(record.created).isoformat(),
+                    "level": record.levelname,
+                    "logger": record.name,
+                    "message": record.getMessage(),
+                })
+        except Exception:
+            # Never let log capture break the application
+            pass
+
+    def recent(self, limit: int = 100, level: Optional[str] = None) -> List[dict]:
+        """Most recent records, newest first, optionally filtered by min level."""
+        min_levelno = logging.getLevelName(level.upper()) if level else logging.NOTSET
+        if not isinstance(min_levelno, int):
+            min_levelno = logging.NOTSET
+
+        with self._lock_buffer:
+            records = list(self._records)
+
+        if min_levelno > logging.NOTSET:
+            records = [
+                r for r in records
+                if logging.getLevelName(r["level"]) >= min_levelno
+            ]
+        return list(reversed(records))[:limit]
+
+
+# Global handler instance; attached to the root logger in main.py
+log_buffer_handler = RingBufferHandler()

--- a/backend/app/manual_trigger_queue.py
+++ b/backend/app/manual_trigger_queue.py
@@ -39,6 +39,7 @@ from sqlalchemy.orm import Session
 from app.models import ApplicationSettings, Channel
 from app.video_download_service import video_download_service
 from app.scheduled_download_job import cleanup_old_videos
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -80,21 +81,21 @@ def add_to_queue(db: Session, channel_id: int) -> int:
         new_entry = {
             "channel_id": channel_id,
             "user": "manual",
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": utc_now().isoformat()
         }
         queue.append(new_entry)
 
         # Save back to database
         if queue_setting:
             queue_setting.value = json.dumps(queue)
-            queue_setting.updated_at = datetime.utcnow()
+            queue_setting.updated_at = utc_now()
         else:
             queue_setting = ApplicationSettings(
                 key=QUEUE_KEY,
                 value=json.dumps(queue),
                 description="Queue for manual download triggers during scheduler runs",
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow()
+                created_at=utc_now(),
+                updated_at=utc_now()
             )
             db.add(queue_setting)
 
@@ -161,7 +162,7 @@ def clear_queue(db: Session):
 
         if queue_setting:
             queue_setting.value = "[]"
-            queue_setting.updated_at = datetime.utcnow()
+            queue_setting.updated_at = utc_now()
             db.commit()
             logger.info("Manual trigger queue cleared")
 
@@ -193,7 +194,7 @@ def remove_stale_entries(db: Session) -> int:
         if not queue:
             return 0
 
-        now = datetime.utcnow()
+        now = utc_now()
         timeout_threshold = now - timedelta(minutes=TIMEOUT_MINUTES)
 
         original_count = len(queue)
@@ -223,7 +224,7 @@ def remove_stale_entries(db: Session) -> int:
 
             if queue_setting:
                 queue_setting.value = json.dumps(fresh_queue)
-                queue_setting.updated_at = datetime.utcnow()
+                queue_setting.updated_at = utc_now()
                 db.commit()
 
         return removed_count

--- a/backend/app/manual_trigger_queue.py
+++ b/backend/app/manual_trigger_queue.py
@@ -31,6 +31,7 @@ Usage:
 """
 
 import json
+import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional, Tuple
@@ -289,9 +290,10 @@ async def process_queue(db: Session) -> Tuple[int, int]:
                 failed += 1
                 continue
 
-            # Process the download
-            success, videos_downloaded, error_message = video_download_service.process_channel_downloads(
-                channel, db
+            # Process the download (worker thread: blocking yt-dlp work
+            # must not stall the shared event loop)
+            success, videos_downloaded, error_message = await asyncio.to_thread(
+                video_download_service.process_channel_downloads, channel, db
             )
 
             if success:

--- a/backend/app/metadata_service.py
+++ b/backend/app/metadata_service.py
@@ -3,7 +3,6 @@ import os
 import re
 import logging
 import shutil
-from datetime import datetime
 from typing import Dict, Optional, Tuple, List
 from pathlib import Path
 from sqlalchemy.orm import Session
@@ -12,6 +11,7 @@ from app.youtube_service import youtube_service
 from app.image_service import image_service
 from app.models import Channel
 from app.config import get_settings
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -263,7 +263,7 @@ class MetadataService:
             
             # Status and timestamp
             channel.metadata_status = "completed"
-            channel.last_metadata_update = datetime.utcnow()
+            channel.last_metadata_update = utc_now()
             
             db.commit()
             

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,8 +1,8 @@
 """SQLAlchemy database models."""
-from datetime import datetime
 from sqlalchemy import Column, Integer, String, Boolean, DateTime, Text, ForeignKey, Index
 from sqlalchemy.orm import relationship
 from app.database import Base
+from app.time_utils import utc_now
 
 
 class Channel(Base):
@@ -49,8 +49,8 @@ class Channel(Base):
     nfo_last_generated = Column(DateTime, nullable=True, index=True)      # Last NFO generation timestamp (NULL = needs backfill)
     
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow)                 # When channel was added
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)  # Last modified
+    created_at = Column(DateTime, default=utc_now)                 # When channel was added
+    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)  # Last modified
     last_check = Column(DateTime, nullable=True)                           # Last time videos were checked
 
     # Relationships
@@ -79,7 +79,7 @@ class Download(Base):
     error_message = Column(Text, nullable=True)
     retry_count = Column(Integer, default=0, nullable=False)  # Failed run attempts; bounds automatic retries
     file_exists = Column(Boolean, default=True, nullable=False)  # Track if downloaded file exists on disk
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
     completed_at = Column(DateTime, nullable=True)
     deleted_at = Column(DateTime, nullable=True)  # When video file was deleted (NULL = not deleted)
 
@@ -102,7 +102,7 @@ class DownloadHistory(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     channel_id = Column(Integer, ForeignKey("channels.id"), nullable=False, index=True)
-    run_date = Column(DateTime, default=datetime.utcnow, index=True)
+    run_date = Column(DateTime, default=utc_now, index=True)
     videos_found = Column(Integer, default=0)
     videos_downloaded = Column(Integer, default=0)
     videos_skipped = Column(Integer, default=0)
@@ -126,8 +126,8 @@ class ApplicationSettings(Base):
     key = Column(String, unique=True, index=True, nullable=False)
     value = Column(Text, nullable=True)
     description = Column(Text, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
+    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
 
     # Indexes
     __table_args__ = (

--- a/backend/app/nfo_backfill_service.py
+++ b/backend/app/nfo_backfill_service.py
@@ -61,6 +61,7 @@ from sqlalchemy.orm import Session
 from app.database import SessionLocal
 from app.models import Channel, ApplicationSettings
 from app.nfo_service import get_nfo_service
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ class NFOBackfillService:
         self.files_created = 0
         self.files_skipped = 0
         self.files_failed = 0
-        self.started_at = datetime.utcnow()
+        self.started_at = utc_now()
 
         # Get database session
         db = SessionLocal()
@@ -189,7 +190,7 @@ class NFOBackfillService:
                 await self._process_channel(channel, db)
 
             # Job completed
-            elapsed = (datetime.utcnow() - self.started_at).total_seconds()
+            elapsed = (utc_now() - self.started_at).total_seconds()
             logger.info(
                 f"NFO backfill completed in {elapsed:.1f}s: "
                 f"{self.channels_processed}/{self.total_channels} channels processed, "
@@ -461,7 +462,7 @@ class NFOBackfillService:
                     files_skipped += 1
 
             # Update timestamp to mark as regenerated
-            channel.nfo_last_generated = datetime.utcnow()
+            channel.nfo_last_generated = utc_now()
             db.commit()
 
             # Enhanced logging: Show summary and details of failures
@@ -610,7 +611,7 @@ class NFOBackfillService:
             # Mark channel as completed (set timestamp)
             # Why update here? Only after all NFO files generated successfully
             # (or with minimal failures - we still mark as done to avoid re-processing)
-            channel.nfo_last_generated = datetime.utcnow()
+            channel.nfo_last_generated = utc_now()
             db.commit()
 
             logger.info(

--- a/backend/app/notification_service.py
+++ b/backend/app/notification_service.py
@@ -1,0 +1,69 @@
+"""Failure notifications via Apprise (operational hardening).
+
+Apprise supports dozens of services (Discord, ntfy, Telegram, email, ...)
+through a single URL syntax, which fits the homelab audience: one setting,
+no per-service integration code. Notifications are strictly best-effort —
+a notification failure must never affect download processing.
+
+Setting: ApplicationSettings key 'notification_url' (blank/missing = disabled).
+"""
+
+import logging
+from typing import Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.models import ApplicationSettings
+
+logger = logging.getLogger(__name__)
+
+NOTIFICATION_URL_KEY = "notification_url"
+
+
+def get_notification_url(db: Session) -> Optional[str]:
+    """Read the configured Apprise URL (None when notifications are disabled)."""
+    try:
+        setting = db.query(ApplicationSettings).filter(
+            ApplicationSettings.key == NOTIFICATION_URL_KEY
+        ).first()
+        if setting and setting.value and setting.value.strip():
+            return setting.value.strip()
+    except Exception as e:
+        logger.warning(f"Failed to read notification URL: {e}")
+    return None
+
+
+def validate_notification_url(url: str) -> Tuple[bool, Optional[str]]:
+    """Check whether Apprise accepts the URL (without sending anything)."""
+    try:
+        import apprise
+        client = apprise.Apprise()
+        if client.add(url):
+            return True, None
+        return False, "Apprise did not recognize this notification URL format"
+    except Exception as e:
+        return False, f"Could not validate notification URL: {e}"
+
+
+def send_notification(db: Session, title: str, body: str) -> bool:
+    """Send a notification if configured. Best-effort: never raises.
+
+    Returns True only when a notification was actually dispatched.
+    """
+    url = get_notification_url(db)
+    if not url:
+        return False
+
+    try:
+        import apprise
+        client = apprise.Apprise()
+        if not client.add(url):
+            logger.warning("Configured notification URL was rejected by Apprise")
+            return False
+        result = client.notify(title=title, body=body)
+        if not result:
+            logger.warning("Notification dispatch reported failure")
+        return bool(result)
+    except Exception as e:
+        logger.warning(f"Failed to send notification: {e}")
+        return False

--- a/backend/app/overlap_prevention.py
+++ b/backend/app/overlap_prevention.py
@@ -28,6 +28,7 @@ from contextlib import contextmanager
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 from app.models import ApplicationSettings
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -92,15 +93,15 @@ def scheduler_lock(db: Session, job_name: str = "scheduler"):
         # Acquire lock atomically
         if running_flag:
             running_flag.value = "true"
-            running_flag.updated_at = datetime.utcnow()
+            running_flag.updated_at = utc_now()
         else:
             # Create flag if it doesn't exist (shouldn't happen if migration ran)
             running_flag = ApplicationSettings(
                 key=lock_key,
                 value="true",
                 description=f"Lock flag to prevent overlapping {job_name} executions",
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow()
+                created_at=utc_now(),
+                updated_at=utc_now()
             )
             db.add(running_flag)
 
@@ -130,7 +131,7 @@ def scheduler_lock(db: Session, job_name: str = "scheduler"):
             try:
                 if running_flag:
                     running_flag.value = "false"
-                    running_flag.updated_at = datetime.utcnow()
+                    running_flag.updated_at = utc_now()
                     db.commit()
                     logger.info(f"Released lock for job '{job_name}'")
             except Exception as e:
@@ -159,18 +160,18 @@ def _update_last_run_timestamp(db: Session, job_name: str):
             ApplicationSettings.key == timestamp_key
         ).first()
 
-        current_time = datetime.utcnow().isoformat()
+        current_time = utc_now().isoformat()
         if last_run_setting:
             last_run_setting.value = current_time
-            last_run_setting.updated_at = datetime.utcnow()
+            last_run_setting.updated_at = utc_now()
         else:
             # Create timestamp setting if it doesn't exist
             last_run_setting = ApplicationSettings(
                 key=timestamp_key,
                 value=current_time,
                 description=f"Timestamp of last successful {job_name} execution",
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow()
+                created_at=utc_now(),
+                updated_at=utc_now()
             )
             db.add(last_run_setting)
 
@@ -214,7 +215,7 @@ def clear_stale_locks(db: Session, max_age_hours: int = 2):
         ).all()
 
         cleared_count = 0
-        now = datetime.utcnow()
+        now = utc_now()
         max_age = max_age_hours * 3600  # Convert to seconds
 
         for flag in running_flags:

--- a/backend/app/progress_store.py
+++ b/backend/app/progress_store.py
@@ -21,10 +21,12 @@ logger = logging.getLogger(__name__)
 class DownloadProgressStore:
     """Thread-safe registry of currently-downloading videos.
 
-    Entries are keyed by video_id alone: channels are processed sequentially
-    (one yt-dlp process at a time, enforced by the shared scheduler lock), so
-    the same video id can never be actively downloading for two channels at
-    once. Revisit the key if parallel channel processing is ever introduced.
+    Entries are keyed by video_id alone. A given video can only be
+    mid-download once at a time by construction, so the key is unique for
+    progress purposes. The one edge to know about: if the same video appears
+    in two channels' feeds AND downloads ever run concurrently (today the
+    shared scheduler lock keeps them sequential), the second start() would
+    overwrite the first entry's channel attribution in the display.
     """
 
     def __init__(self):

--- a/backend/app/progress_store.py
+++ b/backend/app/progress_store.py
@@ -12,8 +12,8 @@ mid-download means the download restarts anyway.
 
 import logging
 import threading
-from datetime import datetime
 from typing import Dict, List, Optional
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +39,8 @@ class DownloadProgressStore:
                 "total_bytes": None,
                 "speed": None,
                 "eta_seconds": None,
-                "started_at": datetime.utcnow().isoformat(),
-                "updated_at": datetime.utcnow().isoformat(),
+                "started_at": utc_now().isoformat(),
+                "updated_at": utc_now().isoformat(),
             }
 
     def update(self, video_id: str, **fields):
@@ -50,7 +50,7 @@ class DownloadProgressStore:
             if entry is None:
                 return
             entry.update(fields)
-            entry["updated_at"] = datetime.utcnow().isoformat()
+            entry["updated_at"] = utc_now().isoformat()
 
     def finish(self, video_id: str):
         """Remove a download from the active set (success or failure)."""

--- a/backend/app/progress_store.py
+++ b/backend/app/progress_store.py
@@ -19,7 +19,13 @@ logger = logging.getLogger(__name__)
 
 
 class DownloadProgressStore:
-    """Thread-safe registry of currently-downloading videos."""
+    """Thread-safe registry of currently-downloading videos.
+
+    Entries are keyed by video_id alone: channels are processed sequentially
+    (one yt-dlp process at a time, enforced by the shared scheduler lock), so
+    the same video id can never be actively downloading for two channels at
+    once. Revisit the key if parallel channel processing is ever introduced.
+    """
 
     def __init__(self):
         self._lock = threading.Lock()

--- a/backend/app/progress_store.py
+++ b/backend/app/progress_store.py
@@ -1,0 +1,102 @@
+"""In-memory store of active download progress (US-010).
+
+Fed by yt-dlp progress hooks from the download worker (a thread), read by
+API handlers (event loop / threadpool). A plain dict guarded by a lock is
+sufficient: writes are frequent but tiny, readers only take snapshots, and
+the store intentionally holds only *active* downloads — completed/failed
+downloads live in the database, not here.
+
+Deliberately not persisted: progress is ephemeral by nature, and a restart
+mid-download means the download restarts anyway.
+"""
+
+import logging
+import threading
+from datetime import datetime
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class DownloadProgressStore:
+    """Thread-safe registry of currently-downloading videos."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._active: Dict[str, dict] = {}
+
+    def start(self, video_id: str, channel_id: int, channel_name: str, title: str):
+        """Register a download as active (called before yt-dlp starts)."""
+        with self._lock:
+            self._active[video_id] = {
+                "video_id": video_id,
+                "channel_id": channel_id,
+                "channel_name": channel_name,
+                "title": title,
+                "status": "starting",
+                "percent": 0.0,
+                "downloaded_bytes": 0,
+                "total_bytes": None,
+                "speed": None,
+                "eta_seconds": None,
+                "started_at": datetime.utcnow().isoformat(),
+                "updated_at": datetime.utcnow().isoformat(),
+            }
+
+    def update(self, video_id: str, **fields):
+        """Merge progress fields for an active download (no-op if unknown)."""
+        with self._lock:
+            entry = self._active.get(video_id)
+            if entry is None:
+                return
+            entry.update(fields)
+            entry["updated_at"] = datetime.utcnow().isoformat()
+
+    def finish(self, video_id: str):
+        """Remove a download from the active set (success or failure)."""
+        with self._lock:
+            self._active.pop(video_id, None)
+
+    def snapshot(self) -> List[dict]:
+        """Copy of all active downloads, oldest first."""
+        with self._lock:
+            return sorted(
+                (dict(entry) for entry in self._active.values()),
+                key=lambda e: e["started_at"],
+            )
+
+    def make_progress_hook(self, video_id: str):
+        """Build a yt-dlp progress hook bound to one video.
+
+        yt-dlp calls the hook per fragment/file with a dict whose 'status' is
+        'downloading' or 'finished'. A single video triggers multiple file
+        downloads (video + audio streams), so percent resets between files —
+        acceptable for a progress display.
+        """
+        def hook(d: dict):
+            try:
+                if d.get("status") == "downloading":
+                    total = d.get("total_bytes") or d.get("total_bytes_estimate")
+                    downloaded = d.get("downloaded_bytes") or 0
+                    percent = (downloaded / total * 100) if total else 0.0
+                    self.update(
+                        video_id,
+                        status="downloading",
+                        percent=round(percent, 1),
+                        downloaded_bytes=downloaded,
+                        total_bytes=total,
+                        speed=d.get("speed"),
+                        eta_seconds=d.get("eta"),
+                    )
+                elif d.get("status") == "finished":
+                    # File finished; yt-dlp may still merge/embed metadata
+                    self.update(video_id, status="processing", percent=100.0)
+            except Exception as e:
+                # A progress-display failure must never break the download
+                logger.debug(f"Progress hook error for {video_id}: {e}")
+
+        return hook
+
+
+# Global instance shared by the download worker and API handlers
+download_progress_store = DownloadProgressStore()

--- a/backend/app/scheduled_download_job.py
+++ b/backend/app/scheduled_download_job.py
@@ -187,6 +187,18 @@ async def scheduled_download_job():
             # Update global job statistics
             _update_job_statistics(downloaded_summary, db)
 
+            # Best-effort failure notification (no-op unless configured)
+            if downloaded_summary["failed_channels"] > 0:
+                from app.notification_service import send_notification
+                send_notification(
+                    db,
+                    "ChannelFinWatcher: scheduled run had failures",
+                    f"{downloaded_summary['failed_channels']} of "
+                    f"{downloaded_summary['total_channels']} channels failed. "
+                    f"{downloaded_summary['total_videos']} videos downloaded. "
+                    f"Check the dashboard for per-channel errors."
+                )
+
     except JobAlreadyRunningError:
         logger.warning("Scheduled download job skipped - another instance already running")
         return
@@ -244,6 +256,13 @@ async def channel_download_job(channel_id: int):
                 )
             else:
                 logger.error(f"Per-channel job for '{channel.name}' failed: {error_message}")
+                # Best-effort failure notification (no-op unless configured)
+                from app.notification_service import send_notification
+                send_notification(
+                    db,
+                    f"ChannelFinWatcher: '{channel.name}' download failed",
+                    f"Scheduled download for '{channel.name}' failed: {error_message}"
+                )
 
     except JobAlreadyRunningError:
         logger.info(

--- a/backend/app/scheduled_download_job.py
+++ b/backend/app/scheduled_download_job.py
@@ -26,7 +26,6 @@ import logging
 import asyncio
 import shutil
 import os
-from datetime import datetime
 from typing import Tuple
 from pathlib import Path
 from sqlalchemy.orm import Session
@@ -36,6 +35,7 @@ from app.models import Channel, ApplicationSettings, DownloadHistory, Download
 from app.video_download_service import video_download_service
 from app.overlap_prevention import scheduler_lock, JobAlreadyRunningError
 from app.utils import is_retryable_error
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +89,7 @@ async def scheduled_download_job():
         "failed_channels": 0,
         "total_videos": 0,
         "total_videos_deleted": 0,
-        "start_time": datetime.utcnow()
+        "start_time": utc_now()
     }
 
     try:
@@ -109,7 +109,7 @@ async def scheduled_download_job():
 
             # Process each channel with individual error handling
             for channel in channels:
-                channel_start_time = datetime.utcnow()
+                channel_start_time = utc_now()
 
                 try:
                     logger.info(f"Processing channel: {channel.name} (ID: {channel.id})")
@@ -138,7 +138,7 @@ async def scheduled_download_job():
                             # Cleanup errors shouldn't stop the job
                             logger.error(f"Cleanup failed for channel '{channel.name}': {e}")
 
-                        processing_time = (datetime.utcnow() - channel_start_time).total_seconds()
+                        processing_time = (utc_now() - channel_start_time).total_seconds()
                         logger.info(
                             f"Channel '{channel.name}' completed successfully: "
                             f"{videos_downloaded} videos in {processing_time:.1f}s"
@@ -158,7 +158,7 @@ async def scheduled_download_job():
                     continue  # Continue with next channel
 
             # Log final summary
-            total_time = (datetime.utcnow() - downloaded_summary["start_time"]).total_seconds()
+            total_time = (utc_now() - downloaded_summary["start_time"]).total_seconds()
             logger.info(
                 f"Scheduled download job completed in {total_time:.1f}s: "
                 f"{downloaded_summary['successful_channels']}/{downloaded_summary['total_channels']} channels successful, "
@@ -376,13 +376,13 @@ def _create_failed_history_record(channel_id: int, error_message: str, db: Sessi
     try:
         history = DownloadHistory(
             channel_id=channel_id,
-            run_date=datetime.utcnow(),
+            run_date=utc_now(),
             videos_found=0,
             videos_downloaded=0,
             videos_skipped=0,
             status='failed',
             error_message=error_message[:500],  # Truncate long errors
-            completed_at=datetime.utcnow()
+            completed_at=utc_now()
         )
         db.add(history)
         db.commit()
@@ -425,14 +425,14 @@ def _update_job_statistics(summary: dict, db: Session):
 
             if setting:
                 setting.value = value
-                setting.updated_at = datetime.utcnow()
+                setting.updated_at = utc_now()
             else:
                 setting = ApplicationSettings(
                     key=key,
                     value=value,
                     description=f"Scheduler statistic: {key}",
-                    created_at=datetime.utcnow(),
-                    updated_at=datetime.utcnow()
+                    created_at=utc_now(),
+                    updated_at=utc_now()
                 )
                 db.add(setting)
 
@@ -527,7 +527,7 @@ async def cleanup_old_videos(channel: Channel, db: Session) -> int:
                 # Mark database record as deleted (preserve history)
                 # Don't delete the record - just mark when it was removed from disk
                 download.file_exists = False
-                download.deleted_at = datetime.utcnow()
+                download.deleted_at = utc_now()
                 deleted_count += 1
                 deleted_video_names.append(download.title)  # Track for summary log
 
@@ -544,7 +544,7 @@ async def cleanup_old_videos(channel: Channel, db: Session) -> int:
                 # Still try to mark the DB record as deleted
                 try:
                     download.file_exists = False
-                    download.deleted_at = datetime.utcnow()
+                    download.deleted_at = utc_now()
                     deleted_count += 1
                     deleted_video_names.append(download.title)  # Track even if file deletion failed
                 except Exception as db_error:

--- a/backend/app/scheduled_download_job.py
+++ b/backend/app/scheduled_download_job.py
@@ -190,7 +190,10 @@ async def scheduled_download_job():
             # Best-effort failure notification (no-op unless configured)
             if downloaded_summary["failed_channels"] > 0:
                 from app.notification_service import send_notification
-                send_notification(
+                # Worker thread: Apprise performs blocking network I/O and a
+                # slow endpoint must not stall the shared event loop
+                await asyncio.to_thread(
+                    send_notification,
                     db,
                     "ChannelFinWatcher: scheduled run had failures",
                     f"{downloaded_summary['failed_channels']} of "
@@ -256,9 +259,11 @@ async def channel_download_job(channel_id: int):
                 )
             else:
                 logger.error(f"Per-channel job for '{channel.name}' failed: {error_message}")
-                # Best-effort failure notification (no-op unless configured)
+                # Best-effort failure notification (no-op unless configured;
+                # worker thread keeps blocking network I/O off the event loop)
                 from app.notification_service import send_notification
-                send_notification(
+                await asyncio.to_thread(
+                    send_notification,
                     db,
                     f"ChannelFinWatcher: '{channel.name}' download failed",
                     f"Scheduled download for '{channel.name}' failed: {error_message}"
@@ -302,10 +307,11 @@ async def _process_channel_with_recovery(channel: Channel, db: Session) -> Tuple
 
     while retry_count < max_retries:
         try:
-            # Use existing video download service
-            # This returns (success, videos_downloaded, error_message)
-            success, videos_downloaded, error_message = video_download_service.process_channel_downloads(
-                channel, db
+            # Use existing video download service (worker thread: this is
+            # minutes of blocking yt-dlp work and the scheduler shares the
+            # event loop with the API)
+            success, videos_downloaded, error_message = await asyncio.to_thread(
+                video_download_service.process_channel_downloads, channel, db
             )
 
             # If successful or non-retryable error, return immediately

--- a/backend/app/scheduler_service.py
+++ b/backend/app/scheduler_service.py
@@ -29,7 +29,6 @@ Usage:
 """
 
 import logging
-from datetime import datetime
 from typing import Dict, List, Optional
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,7 +1,7 @@
 """Pydantic schemas for API request/response validation."""
 from datetime import datetime
 from typing import Optional, List, Literal
-from pydantic import BaseModel, HttpUrl, Field
+from pydantic import BaseModel, ConfigDict, HttpUrl, Field
 
 # Quality presets supported by the download pipeline (US-015).
 # Must stay in sync with VideoDownloadService.QUALITY_FORMATS.
@@ -58,8 +58,7 @@ class Channel(ChannelBase, TimestampMixin):
     cover_image_path: Optional[str] = Field(None, description="Path to cover image")
     backdrop_image_path: Optional[str] = Field(None, description="Path to backdrop image")
 
-    class Config:
-        from_attributes = True  # Allows creation from SQLAlchemy models
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Download schemas
@@ -88,8 +87,7 @@ class Download(DownloadBase):
     created_at: datetime = Field(..., description="When download was created")
     completed_at: Optional[datetime] = Field(None, description="When download completed")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Download History schemas
@@ -115,8 +113,7 @@ class DownloadHistory(DownloadHistoryBase):
     error_message: Optional[str] = Field(None, description="Run-level error message")
     status: str = Field(..., description="Overall run status")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Application Settings schemas
@@ -142,8 +139,7 @@ class ApplicationSetting(ApplicationSettingBase, TimestampMixin):
     """Complete application setting schema for API responses."""
     id: int
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Response schemas for collections
@@ -269,8 +265,7 @@ class DefaultVideoLimitResponse(BaseModel):
     description: str = Field(..., description="Setting description")
     updated_at: datetime = Field(..., description="When setting was last updated")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # NFO settings schemas (Story 008)
@@ -340,8 +335,7 @@ class DefaultQualityResponse(BaseModel):
     description: str = Field(..., description="Setting description")
     updated_at: Optional[datetime] = Field(None, description="When setting was last updated")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Notification settings schema (operational hardening)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -344,6 +344,12 @@ class DefaultQualityResponse(BaseModel):
         from_attributes = True
 
 
+# Notification settings schema (operational hardening)
+class NotificationSettingsUpdate(BaseModel):
+    """Schema for setting the Apprise notification URL (blank disables)."""
+    url: Optional[str] = Field(None, max_length=1000, description="Apprise notification URL, blank to disable")
+
+
 # Error response schemas
 class ErrorDetail(BaseModel):
     """Error detail schema."""

--- a/backend/app/time_utils.py
+++ b/backend/app/time_utils.py
@@ -1,0 +1,22 @@
+"""Single source of truth for timestamps.
+
+Storage convention: DATETIME columns hold NAIVE UTC values. SQLite stores
+datetimes as text, the API serializes them without a UTC offset, and the
+frontend appends 'Z' when parsing — so the naive-UTC convention must be
+preserved end to end. These helpers keep that convention while sourcing
+time from the timezone-aware clock, replacing the deprecated
+datetime.utcnow() / datetime.utcfromtimestamp() (Python 3.12+).
+
+Import this module instead of calling datetime.utcnow() anywhere.
+"""
+from datetime import datetime, timezone
+
+
+def utc_now() -> datetime:
+    """Current UTC time as a naive datetime (storage convention)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def utc_from_timestamp(ts: float) -> datetime:
+    """Convert an epoch timestamp to a naive UTC datetime (storage convention)."""
+    return datetime.fromtimestamp(ts, tz=timezone.utc).replace(tzinfo=None)

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -7,6 +7,7 @@ import re
 from pathlib import Path
 from typing import Dict, Any, List
 from app.config import get_settings
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -425,7 +426,6 @@ def initialize_default_settings(db_session) -> bool:
     """
     try:
         from app.models import ApplicationSettings
-        from datetime import datetime
         
         # Define default settings
         default_settings = [
@@ -467,8 +467,8 @@ def initialize_default_settings(db_session) -> bool:
                     key=setting_data['key'],
                     value=setting_data['value'],
                     description=setting_data['description'],
-                    created_at=datetime.utcnow(),
-                    updated_at=datetime.utcnow()
+                    created_at=utc_now(),
+                    updated_at=utc_now()
                 )
                 db_session.add(setting)
                 logger.info(f"Initialized default setting: {setting_data['key']} = {setting_data['value']}")

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -13,6 +13,7 @@ from app.models import Channel, Download, DownloadHistory
 from app.config import get_settings
 from app.utils import channel_dir_name, is_retryable_error
 from app.nfo_service import get_nfo_service
+from app.progress_store import download_progress_store
 
 logger = logging.getLogger(__name__)
 
@@ -1062,6 +1063,10 @@ class VideoDownloadService:
             # Apply the channel's quality preset (US-015); unknown presets
             # fall back to 'best' with a warning rather than failing
             opts['format'] = self.format_for_quality(channel.quality_preset)
+            # Real-time progress reporting (US-010): register with the
+            # progress store and stream yt-dlp progress into it
+            download_progress_store.start(video_id, channel.id, channel.name, video_title)
+            opts['progress_hooks'] = [download_progress_store.make_progress_hook(video_id)]
             video_url = f"https://www.youtube.com/watch?v={video_id}"
 
             # Verify the cookie file referenced in options is still present on disk
@@ -1195,14 +1200,18 @@ class VideoDownloadService:
         except Exception as e:
             error_msg = str(e)
             logger.error(f"Unexpected error downloading {video_title} ({video_id}): {error_msg}")
-            
+
             # Update download record with error
             if 'download' in locals():
                 download.status = 'failed'
                 download.error_message = error_msg[:500]
                 db.commit()
-            
+
             return False, f"Unexpected error: {error_msg}"
+        finally:
+            # Always clear from the active-progress display, on every exit
+            # path (no-op when the download never registered)
+            download_progress_store.finish(video_id)
     
     def process_channel_downloads(self, channel: Channel, db: Session) -> Tuple[bool, int, Optional[str]]:
         """

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -14,6 +14,7 @@ from app.config import get_settings
 from app.utils import channel_dir_name, is_retryable_error
 from app.nfo_service import get_nfo_service
 from app.progress_store import download_progress_store
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -1132,7 +1133,7 @@ class VideoDownloadService:
                             )
 
                     # Mark as completed AFTER all metadata is populated
-                    download.completed_at = datetime.utcnow()
+                    download.completed_at = utc_now()
                     db.commit()
 
                     # ========================================================================
@@ -1239,7 +1240,7 @@ class VideoDownloadService:
         # Create download history record
         history = DownloadHistory(
             channel_id=channel.id,
-            run_date=datetime.utcnow(),
+            run_date=utc_now(),
             videos_found=0,
             videos_downloaded=0,
             videos_skipped=0,
@@ -1255,7 +1256,7 @@ class VideoDownloadService:
             if not success:
                 history.status = 'failed'
                 history.error_message = error
-                history.completed_at = datetime.utcnow()
+                history.completed_at = utc_now()
                 db.commit()
                 return False, 0, error
 
@@ -1267,8 +1268,8 @@ class VideoDownloadService:
             if not videos:
                 # No videos found, but not an error
                 history.status = 'completed'
-                history.completed_at = datetime.utcnow()
-                channel.last_check = datetime.utcnow()
+                history.completed_at = utc_now()
+                channel.last_check = utc_now()
                 db.commit()
                 logger.info(f"⚠️  No videos found for channel: {channel.name}")
                 return True, 0, None
@@ -1300,8 +1301,8 @@ class VideoDownloadService:
                 logger.info(f"✓ All {len(existing_videos)} videos already downloaded, nothing new to download")
                 history.status = 'completed'
                 history.videos_skipped = len(existing_videos)
-                history.completed_at = datetime.utcnow()
-                channel.last_check = datetime.utcnow()
+                history.completed_at = utc_now()
+                channel.last_check = utc_now()
                 db.commit()
                 return True, 0, None
 
@@ -1330,9 +1331,9 @@ class VideoDownloadService:
             history.videos_downloaded = downloaded_count
             history.videos_skipped = skipped_count
             history.status = 'completed'
-            history.completed_at = datetime.utcnow()
+            history.completed_at = utc_now()
 
-            channel.last_check = datetime.utcnow()
+            channel.last_check = utc_now()
 
             db.commit()
 
@@ -1346,8 +1347,8 @@ class VideoDownloadService:
             
             history.status = 'failed'
             history.error_message = error_msg[:500]
-            history.completed_at = datetime.utcnow()
-            channel.last_check = datetime.utcnow()
+            history.completed_at = utc_now()
+            channel.last_check = utc_now()
             db.commit()
             
             return False, 0, error_msg

--- a/backend/main.py
+++ b/backend/main.py
@@ -31,6 +31,7 @@ from app.utils import (
 )
 from app.api import router as api_router
 from app.scheduler_service import scheduler_service
+from app.time_utils import utc_now
 
 
 class AccessLogFilter(logging.Filter):
@@ -314,7 +315,7 @@ async def health_check(db: Session = Depends(get_db)):
         if last_run_row and last_run_row.value:
             scheduler["last_run"] = last_run_row.value
             last_run = datetime.fromisoformat(last_run_row.value.replace("Z", "+00:00"))
-            if scheduler["enabled"] and datetime.utcnow() - last_run > timedelta(hours=48):
+            if scheduler["enabled"] and utc_now() - last_run > timedelta(hours=48):
                 scheduler["stale"] = True
                 problems.append("scheduler enabled but has not run in over 48h")
     except Exception as e:

--- a/backend/main.py
+++ b/backend/main.py
@@ -296,6 +296,9 @@ async def health_check(db: Session = Depends(get_db)):
             "free_bytes": usage.free,
             "usage_percent": percent,
         }
+        # Deliberately stricter than the dashboard's 80% heads-up banner
+        # (US-012): 80% is a UI nudge to lower limits, 90% is an operational
+        # problem worth flagging in healthchecks/monitors.
         if percent >= 90:
             problems.append(f"disk {percent}% full")
     except OSError as e:

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,11 @@ logging.basicConfig(level=logging.INFO, force=True)
 # This is necessary because some loggers may inherit WARNING level from other configurations
 logging.getLogger('app').setLevel(logging.INFO)
 
+# Capture recent log records in memory for the /api/v1/logs/recent endpoint
+# (US-014). Attached to the root logger so all module logs are captured.
+from app.log_buffer import log_buffer_handler  # noqa: E402 (needs logging configured first)
+logging.getLogger().addHandler(log_buffer_handler)
+
 # Now import app modules (services will be instantiated with logging configured)
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Depends
@@ -242,10 +247,16 @@ async def root():
 async def health_check(db: Session = Depends(get_db)):
     """
     System health check endpoint.
-    
-    Verifies database connectivity and directory structure.
-    Returns comprehensive system status information.
+
+    Verifies database connectivity, directory structure, external tool
+    availability (yt-dlp, ffmpeg/ffprobe), disk capacity, and scheduler
+    liveness. Status is 'healthy' or 'degraded' (with reasons listed) —
+    the endpoint always returns 200 so container healthchecks measure
+    reachability, while the payload carries the diagnosis.
     """
+    import shutil as _shutil
+    problems = []
+
     try:
         # Test database connection
         from sqlalchemy import text
@@ -254,16 +265,71 @@ async def health_check(db: Session = Depends(get_db)):
     except Exception as e:
         logger.error(f"Database health check failed: {e}")
         db_status = f"error: {str(e)}"
-    
+        problems.append("database unreachable")
+
     # Get directory information
     directories = get_directory_info()
-    
+
+    # External tools the download pipeline depends on
+    try:
+        import yt_dlp
+        ytdlp_version = getattr(yt_dlp.version, "__version__", "unknown")
+    except Exception:
+        ytdlp_version = None
+        problems.append("yt-dlp not importable")
+    tools = {
+        "yt_dlp_version": ytdlp_version,
+        "ffmpeg": _shutil.which("ffmpeg") is not None,
+        "ffprobe": _shutil.which("ffprobe") is not None,
+    }
+    if not tools["ffmpeg"]:
+        problems.append("ffmpeg not found (merging/embedding will fail)")
+
+    # Disk capacity for the media volume
+    disk = None
+    try:
+        usage = _shutil.disk_usage(settings.media_dir)
+        percent = round(usage.used / usage.total * 100, 1) if usage.total else 0.0
+        disk = {
+            "total_bytes": usage.total,
+            "free_bytes": usage.free,
+            "usage_percent": percent,
+        }
+        if percent >= 90:
+            problems.append(f"disk {percent}% full")
+    except OSError as e:
+        problems.append(f"media volume unreadable: {e}")
+
+    # Scheduler liveness: enabled but silent for over 48h means something is
+    # wrong regardless of the configured cadence (default schedules are daily)
+    scheduler = {"enabled": None, "last_run": None, "stale": False}
+    try:
+        from app.models import ApplicationSettings
+        from datetime import datetime, timedelta
+        enabled_row = db.query(ApplicationSettings).filter(
+            ApplicationSettings.key == "scheduler_enabled").first()
+        last_run_row = db.query(ApplicationSettings).filter(
+            ApplicationSettings.key == "scheduled_downloads_last_run").first()
+        scheduler["enabled"] = bool(enabled_row and enabled_row.value == "true")
+        if last_run_row and last_run_row.value:
+            scheduler["last_run"] = last_run_row.value
+            last_run = datetime.fromisoformat(last_run_row.value.replace("Z", "+00:00"))
+            if scheduler["enabled"] and datetime.utcnow() - last_run > timedelta(hours=48):
+                scheduler["stale"] = True
+                problems.append("scheduler enabled but has not run in over 48h")
+    except Exception as e:
+        logger.warning(f"Scheduler health probe failed: {e}")
+
     return {
-        "status": "healthy",
+        "status": "degraded" if problems else "healthy",
+        "problems": problems,
         "service": settings.app_name,
         "version": settings.app_version,
         "database": db_status,
-        "directories": directories
+        "directories": directories,
+        "tools": tools,
+        "disk": disk,
+        "scheduler": scheduler,
     }
 
 

--- a/backend/tests/integration/test_api.py
+++ b/backend/tests/integration/test_api.py
@@ -14,7 +14,9 @@ class TestHealthEndpoint:
 
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "healthy"
+        assert data["status"] in ["healthy", "degraded"]
+        if data["status"] == "degraded":
+            assert data["problems"]
         assert "database" in data
         assert data["database"] == "connected"
         assert "directories" in data

--- a/backend/tests/integration/test_dashboard_api.py
+++ b/backend/tests/integration/test_dashboard_api.py
@@ -6,12 +6,13 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.models import Channel, Download, DownloadHistory
+from app.time_utils import utc_now
 
 
 @pytest.fixture
 def dashboard_fixture(db_session):
     """Two channels with downloads and run history, one never-checked channel."""
-    now = datetime.utcnow()
+    now = utc_now()
 
     active = Channel(
         url="https://youtube.com/@active",

--- a/backend/tests/integration/test_download_api.py
+++ b/backend/tests/integration/test_download_api.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.models import Channel, Download, DownloadHistory
+from app.time_utils import utc_now
 
 
 @pytest.fixture
@@ -84,7 +85,7 @@ class TestDownloadAPI:
         """Test retrieving download history for a channel."""
         # Create some test downloads
         from datetime import timedelta
-        now = datetime.utcnow()
+        now = utc_now()
         
         download1 = Download(
             channel_id=test_channel_with_metadata.id,
@@ -123,7 +124,7 @@ class TestDownloadAPI:
     def test_get_channel_downloads_with_pagination(self, test_client: TestClient, db_session: Session, test_channel_with_metadata):
         """Test download history with pagination parameters."""
         # Create multiple downloads
-        now = datetime.utcnow()
+        now = utc_now()
         for i in range(5):
             download = Download(
                 channel_id=test_channel_with_metadata.id,
@@ -154,7 +155,7 @@ class TestDownloadAPI:
 
     def test_get_download_details(self, test_client: TestClient, db_session: Session, test_channel_with_metadata):
         """Test retrieving individual download details."""
-        now = datetime.utcnow()
+        now = utc_now()
         download = Download(
             channel_id=test_channel_with_metadata.id,
             video_id="test123",

--- a/backend/tests/integration/test_download_progress.py
+++ b/backend/tests/integration/test_download_progress.py
@@ -78,6 +78,43 @@ class TestProgressStore:
         # No exception raised - download must not be affected by display errors
 
 
+class TestProgressStream:
+    """Tests for the SSE progress event generator."""
+
+    @pytest.mark.asyncio
+    async def test_event_generator_emits_snapshots_until_disconnect(self):
+        import json
+        from app.api import _progress_event_stream
+
+        class FakeRequest:
+            """Reports connected for the first check, disconnected after."""
+            def __init__(self):
+                self.checks = 0
+
+            async def is_disconnected(self):
+                self.checks += 1
+                return self.checks > 1
+
+        download_progress_store.start("vid_sse_1", 1, "SSE Channel", "SSE Video")
+        download_progress_store.update("vid_sse_1", status="downloading", percent=12.5)
+        try:
+            gen = _progress_event_stream(FakeRequest())
+
+            event = await gen.__anext__()
+            assert event.startswith("data: ")
+            assert event.endswith("\n\n")
+            payload = json.loads(event[len("data: "):])
+            assert payload["count"] == 1
+            assert payload["active"][0]["video_id"] == "vid_sse_1"
+            assert payload["active"][0]["percent"] == 12.5
+
+            # Second iteration sees the disconnect and ends the stream
+            with pytest.raises(StopAsyncIteration):
+                await gen.__anext__()
+        finally:
+            download_progress_store.finish("vid_sse_1")
+
+
 class TestActiveDownloadsEndpoint:
     """Tests for GET /api/v1/downloads/active."""
 

--- a/backend/tests/integration/test_download_progress.py
+++ b/backend/tests/integration/test_download_progress.py
@@ -1,0 +1,102 @@
+"""Tests for real-time download progress (US-010: Active Download Progress)."""
+import pytest
+from fastapi.testclient import TestClient
+
+from app.progress_store import DownloadProgressStore, download_progress_store
+
+
+class TestProgressStore:
+    """Unit tests for the in-memory progress store."""
+
+    def test_start_update_snapshot_finish_lifecycle(self):
+        store = DownloadProgressStore()
+
+        store.start("vid1", 1, "Channel A", "Video One")
+        store.update("vid1", status="downloading", percent=42.5,
+                     downloaded_bytes=425, total_bytes=1000, speed=100.0, eta_seconds=6)
+
+        snapshot = store.snapshot()
+        assert len(snapshot) == 1
+        entry = snapshot[0]
+        assert entry["video_id"] == "vid1"
+        assert entry["channel_name"] == "Channel A"
+        assert entry["percent"] == 42.5
+        assert entry["status"] == "downloading"
+
+        store.finish("vid1")
+        assert store.snapshot() == []
+
+    def test_update_unknown_video_is_noop(self):
+        store = DownloadProgressStore()
+        store.update("ghost", percent=50)  # Must not raise or create entries
+        assert store.snapshot() == []
+
+    def test_finish_unknown_video_is_noop(self):
+        store = DownloadProgressStore()
+        store.finish("ghost")  # Must not raise
+
+    def test_snapshot_is_a_copy(self):
+        store = DownloadProgressStore()
+        store.start("vid1", 1, "A", "T")
+        snapshot = store.snapshot()
+        snapshot[0]["percent"] = 99.0
+        assert store.snapshot()[0]["percent"] == 0.0
+
+    def test_progress_hook_translates_ytdlp_events(self):
+        store = DownloadProgressStore()
+        store.start("vid1", 1, "A", "T")
+        hook = store.make_progress_hook("vid1")
+
+        hook({"status": "downloading", "downloaded_bytes": 500,
+              "total_bytes": 2000, "speed": 250.0, "eta": 6})
+        entry = store.snapshot()[0]
+        assert entry["status"] == "downloading"
+        assert entry["percent"] == 25.0
+        assert entry["speed"] == 250.0
+
+        hook({"status": "finished"})
+        entry = store.snapshot()[0]
+        assert entry["status"] == "processing"
+        assert entry["percent"] == 100.0
+
+    def test_progress_hook_handles_missing_totals(self):
+        store = DownloadProgressStore()
+        store.start("vid1", 1, "A", "T")
+        hook = store.make_progress_hook("vid1")
+
+        # Live streams / unknown sizes have no total_bytes at all
+        hook({"status": "downloading", "downloaded_bytes": 500})
+        entry = store.snapshot()[0]
+        assert entry["percent"] == 0.0
+        assert entry["total_bytes"] is None
+
+    def test_hook_errors_never_propagate(self):
+        store = DownloadProgressStore()
+        store.start("vid1", 1, "A", "T")
+        hook = store.make_progress_hook("vid1")
+        hook({"status": "downloading", "downloaded_bytes": "not-a-number", "total_bytes": 100})
+        # No exception raised - download must not be affected by display errors
+
+
+class TestActiveDownloadsEndpoint:
+    """Tests for GET /api/v1/downloads/active."""
+
+    def test_empty_when_idle(self, test_client: TestClient):
+        response = test_client.get("/api/v1/downloads/active")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 0
+        assert data["active"] == []
+
+    def test_reflects_global_store(self, test_client: TestClient):
+        download_progress_store.start("vid_api_1", 7, "API Channel", "API Video")
+        download_progress_store.update("vid_api_1", status="downloading", percent=33.3)
+        try:
+            response = test_client.get("/api/v1/downloads/active")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["count"] == 1
+            assert data["active"][0]["video_id"] == "vid_api_1"
+            assert data["active"][0]["percent"] == 33.3
+        finally:
+            download_progress_store.finish("vid_api_1")

--- a/backend/tests/integration/test_global_downloads_api.py
+++ b/backend/tests/integration/test_global_downloads_api.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.models import Channel, Download, ApplicationSettings
+from app.time_utils import utc_now
 
 
 @pytest.fixture
@@ -33,7 +34,7 @@ def two_channels_with_downloads(db_session):
     db_session.refresh(channel_a)
     db_session.refresh(channel_b)
 
-    now = datetime.utcnow()
+    now = utc_now()
     downloads = [
         Download(
             channel_id=channel_a.id,
@@ -124,7 +125,7 @@ class TestGlobalDownloadsList:
         """file_exists/deleted_at must reflect the ORM row, not schema defaults,
         so the UI can show cleaned-up videos correctly."""
         channel_a, _ = two_channels_with_downloads
-        cleanup_time = datetime.utcnow() - timedelta(minutes=30)
+        cleanup_time = utc_now() - timedelta(minutes=30)
         db_session.add(Download(
             channel_id=channel_a.id,
             video_id="vid_a_cleaned",
@@ -132,7 +133,7 @@ class TestGlobalDownloadsList:
             status="completed",
             file_exists=False,
             deleted_at=cleanup_time,
-            created_at=datetime.utcnow()
+            created_at=utc_now()
         ))
         db_session.commit()
 

--- a/backend/tests/integration/test_health.py
+++ b/backend/tests/integration/test_health.py
@@ -38,7 +38,10 @@ class TestHealthEndpoint:
         assert "database" in data  # Database connection field
         
         # Status should be positive
-        assert data["status"] in ["healthy", "ok"]
+        assert data["status"] in ["healthy", "degraded"]
+        # Degraded must always be explained
+        if data["status"] == "degraded":
+            assert data["problems"]
         
     def test_health_endpoint_database_connectivity(self, test_client):
         """Test health endpoint confirms database connectivity."""
@@ -76,4 +79,7 @@ class TestHealthEndpoint:
         for response in responses:
             assert response.status_code == 200
             data = response.json()
-            assert data["status"] in ["healthy", "ok"]
+            assert data["status"] in ["healthy", "degraded"]
+        # Degraded must always be explained
+        if data["status"] == "degraded":
+            assert data["problems"]

--- a/backend/tests/integration/test_operational_hardening.py
+++ b/backend/tests/integration/test_operational_hardening.py
@@ -1,0 +1,162 @@
+"""Tests for operational hardening: deep health checks, cookie status,
+notifications, and the recent-logs buffer."""
+import logging
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.log_buffer import RingBufferHandler
+from app.models import ApplicationSettings
+from app.notification_service import (
+    get_notification_url,
+    send_notification,
+    validate_notification_url,
+)
+
+
+class TestDeepHealthCheck:
+    """Tests for the enriched /health endpoint."""
+
+    def test_healthy_payload_shape(self, test_client: TestClient):
+        response = test_client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] in ("healthy", "degraded")
+        assert isinstance(data["problems"], list)
+        assert "tools" in data
+        assert "yt_dlp_version" in data["tools"]
+        assert isinstance(data["tools"]["ffmpeg"], bool)
+        assert "scheduler" in data
+        assert "database" in data
+
+    def test_scheduler_staleness_flagged(self, test_client: TestClient, db_session):
+        db_session.add_all([
+            ApplicationSettings(key="scheduler_enabled", value="true"),
+            ApplicationSettings(key="scheduled_downloads_last_run",
+                                value="2020-01-01T00:00:00"),
+        ])
+        db_session.commit()
+
+        response = test_client.get("/health")
+
+        data = response.json()
+        assert data["scheduler"]["stale"] is True
+        assert data["status"] == "degraded"
+        assert any("scheduler" in p for p in data["problems"])
+
+
+class TestCookiesStatus:
+    """Tests for GET /api/v1/settings/cookies-status."""
+
+    def test_missing_cookie_file(self, test_client: TestClient):
+        with patch("app.api.os.path.exists", return_value=False):
+            response = test_client.get("/api/v1/settings/cookies-status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["present"] is False
+        assert data["stale"] is False
+
+    def test_present_cookie_file_reports_age(self, test_client: TestClient, tmp_path):
+        cookie_file = tmp_path / "cookies.txt"
+        cookie_file.write_text("# Netscape HTTP Cookie File\n")
+
+        with patch("app.api.get_settings") as mock_settings:
+            mock_settings.return_value.cookies_file = str(cookie_file)
+            response = test_client.get("/api/v1/settings/cookies-status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["present"] is True
+        assert data["size_bytes"] > 0
+        assert data["age_days"] == 0
+        assert data["stale"] is False
+
+
+class TestNotificationSettings:
+    """Tests for notification configuration and dispatch."""
+
+    def test_get_disabled_by_default(self, test_client: TestClient):
+        response = test_client.get("/api/v1/settings/notifications")
+        assert response.status_code == 200
+        assert response.json() == {"url": "", "enabled": False}
+
+    def test_put_valid_url_persists(self, test_client: TestClient, db_session):
+        # json:// is a built-in Apprise scheme that needs no external service
+        response = test_client.put(
+            "/api/v1/settings/notifications",
+            json={"url": "json://localhost/webhook"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["enabled"] is True
+        assert get_notification_url(db_session) == "json://localhost/webhook"
+
+    def test_put_invalid_url_rejected(self, test_client: TestClient):
+        response = test_client.put(
+            "/api/v1/settings/notifications",
+            json={"url": "not-a-real-scheme-xyz"},
+        )
+        assert response.status_code == 400
+
+    def test_put_blank_disables(self, test_client: TestClient, db_session):
+        db_session.add(ApplicationSettings(key="notification_url", value="json://localhost/x"))
+        db_session.commit()
+
+        response = test_client.put("/api/v1/settings/notifications", json={"url": ""})
+
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False
+        assert get_notification_url(db_session) is None
+
+    def test_test_endpoint_requires_configuration(self, test_client: TestClient):
+        response = test_client.post("/api/v1/settings/notifications/test")
+        assert response.status_code == 400
+
+    def test_send_notification_noop_when_unconfigured(self, db_session):
+        assert send_notification(db_session, "t", "b") is False
+
+    def test_validate_url(self):
+        assert validate_notification_url("json://localhost/webhook")[0] is True
+        assert validate_notification_url("garbage")[0] is False
+
+
+class TestRecentLogs:
+    """Tests for the in-memory log buffer and endpoint."""
+
+    def test_ring_buffer_captures_and_filters(self):
+        handler = RingBufferHandler()
+        logger = logging.getLogger("test.ring.buffer")
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+        try:
+            logger.info("info message")
+            logger.warning("warning message")
+            logger.error("error message")
+        finally:
+            logger.removeHandler(handler)
+
+        all_records = handler.recent(limit=10)
+        assert [r["message"] for r in all_records[:3]] == [
+            "error message", "warning message", "info message"
+        ]
+
+        warnings_up = handler.recent(limit=10, level="WARNING")
+        assert all(r["level"] in ("WARNING", "ERROR", "CRITICAL") for r in warnings_up)
+        assert len(warnings_up) == 2
+
+    def test_endpoint_returns_records(self, test_client: TestClient):
+        # The endpoint reads the global handler; emit through the root logger
+        logging.getLogger("app.test_logs").warning("hardening probe message")
+
+        response = test_client.get("/api/v1/logs/recent?limit=50&level=WARNING")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data["logs"], list)
+
+    def test_endpoint_rejects_bad_level(self, test_client: TestClient):
+        response = test_client.get("/api/v1/logs/recent?level=LOUD")
+        assert response.status_code == 400

--- a/backend/tests/unit/test_manual_trigger_queue.py
+++ b/backend/tests/unit/test_manual_trigger_queue.py
@@ -21,6 +21,7 @@ from app.manual_trigger_queue import (
     TIMEOUT_MINUTES
 )
 from app.models import ApplicationSettings, Channel
+from app.time_utils import utc_now
 
 
 class TestAddToQueue:
@@ -46,13 +47,13 @@ class TestAddToQueue:
     def test_adds_entry_to_existing_queue(self, db_session):
         """Test adding entry to existing queue."""
         # Create initial queue
-        initial_queue = [{"channel_id": 111, "user": "manual", "timestamp": datetime.utcnow().isoformat()}]
+        initial_queue = [{"channel_id": 111, "user": "manual", "timestamp": utc_now().isoformat()}]
         queue_setting = ApplicationSettings(
             key=QUEUE_KEY,
             value=json.dumps(initial_queue),
             description="Queue",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db_session.add(queue_setting)
         db_session.commit()
@@ -84,16 +85,16 @@ class TestGetQueue:
     def test_returns_queue_entries(self, db_session):
         """Test returns queue entries."""
         entries = [
-            {"channel_id": 111, "user": "manual", "timestamp": datetime.utcnow().isoformat()},
-            {"channel_id": 222, "user": "manual", "timestamp": datetime.utcnow().isoformat()}
+            {"channel_id": 111, "user": "manual", "timestamp": utc_now().isoformat()},
+            {"channel_id": 222, "user": "manual", "timestamp": utc_now().isoformat()}
         ]
 
         queue_setting = ApplicationSettings(
             key=QUEUE_KEY,
             value=json.dumps(entries),
             description="Queue",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db_session.add(queue_setting)
         db_session.commit()
@@ -111,13 +112,13 @@ class TestClearQueue:
     def test_clears_existing_queue(self, db_session):
         """Test clears existing queue."""
         # Create queue
-        entries = [{"channel_id": 111, "user": "manual", "timestamp": datetime.utcnow().isoformat()}]
+        entries = [{"channel_id": 111, "user": "manual", "timestamp": utc_now().isoformat()}]
         queue_setting = ApplicationSettings(
             key=QUEUE_KEY,
             value=json.dumps(entries),
             description="Queue",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db_session.add(queue_setting)
         db_session.commit()
@@ -138,8 +139,8 @@ class TestRemoveStaleEntries:
 
     def test_removes_stale_entries(self, db_session):
         """Test removes entries older than timeout."""
-        stale_time = (datetime.utcnow() - timedelta(minutes=TIMEOUT_MINUTES + 1)).isoformat()
-        fresh_time = datetime.utcnow().isoformat()
+        stale_time = (utc_now() - timedelta(minutes=TIMEOUT_MINUTES + 1)).isoformat()
+        fresh_time = utc_now().isoformat()
 
         entries = [
             {"channel_id": 111, "user": "manual", "timestamp": stale_time},
@@ -150,8 +151,8 @@ class TestRemoveStaleEntries:
             key=QUEUE_KEY,
             value=json.dumps(entries),
             description="Queue",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db_session.add(queue_setting)
         db_session.commit()
@@ -171,7 +172,7 @@ class TestRemoveStaleEntries:
 
     def test_keeps_fresh_entries(self, db_session):
         """Test keeps entries within timeout."""
-        fresh_time = datetime.utcnow().isoformat()
+        fresh_time = utc_now().isoformat()
 
         entries = [
             {"channel_id": 111, "user": "manual", "timestamp": fresh_time},
@@ -182,8 +183,8 @@ class TestRemoveStaleEntries:
             key=QUEUE_KEY,
             value=json.dumps(entries),
             description="Queue",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db_session.add(queue_setting)
         db_session.commit()
@@ -225,16 +226,16 @@ class TestProcessQueue:
 
         # Create queue
         entries = [
-            {"channel_id": channel1.id, "user": "manual", "timestamp": datetime.utcnow().isoformat()},
-            {"channel_id": channel2.id, "user": "manual", "timestamp": datetime.utcnow().isoformat()}
+            {"channel_id": channel1.id, "user": "manual", "timestamp": utc_now().isoformat()},
+            {"channel_id": channel2.id, "user": "manual", "timestamp": utc_now().isoformat()}
         ]
 
         queue_setting = ApplicationSettings(
             key=QUEUE_KEY,
             value=json.dumps(entries),
             description="Queue",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db_session.add(queue_setting)
         db_session.commit()
@@ -284,16 +285,16 @@ class TestProcessQueue:
 
         # Create queue
         entries = [
-            {"channel_id": channel1.id, "user": "manual", "timestamp": datetime.utcnow().isoformat()},
-            {"channel_id": channel2.id, "user": "manual", "timestamp": datetime.utcnow().isoformat()}
+            {"channel_id": channel1.id, "user": "manual", "timestamp": utc_now().isoformat()},
+            {"channel_id": channel2.id, "user": "manual", "timestamp": utc_now().isoformat()}
         ]
 
         queue_setting = ApplicationSettings(
             key=QUEUE_KEY,
             value=json.dumps(entries),
             description="Queue",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db_session.add(queue_setting)
         db_session.commit()
@@ -313,7 +314,7 @@ class TestProcessQueue:
     @patch('app.manual_trigger_queue.video_download_service')
     async def test_removes_stale_entries_before_processing(self, mock_service, db_session):
         """Test removes stale entries before processing."""
-        stale_time = (datetime.utcnow() - timedelta(minutes=TIMEOUT_MINUTES + 1)).isoformat()
+        stale_time = (utc_now() - timedelta(minutes=TIMEOUT_MINUTES + 1)).isoformat()
 
         # Create channel
         channel = Channel(
@@ -329,15 +330,15 @@ class TestProcessQueue:
         # Create queue with stale entry
         entries = [
             {"channel_id": 999, "user": "manual", "timestamp": stale_time},  # Stale, non-existent channel
-            {"channel_id": channel.id, "user": "manual", "timestamp": datetime.utcnow().isoformat()}
+            {"channel_id": channel.id, "user": "manual", "timestamp": utc_now().isoformat()}
         ]
 
         queue_setting = ApplicationSettings(
             key=QUEUE_KEY,
             value=json.dumps(entries),
             description="Queue",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db_session.add(queue_setting)
         db_session.commit()

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from sqlalchemy.exc import IntegrityError
 
 from app.models import Channel, Download, DownloadHistory, ApplicationSettings
+from app.time_utils import utc_now
 
 
 class TestChannelModel:
@@ -207,5 +208,5 @@ class TestApplicationSettingsModel:
         db_session.commit()
         
         # updated_at should change (though this might be subtle in fast tests)
-        # In real usage, the onupdate=datetime.utcnow would update this
+        # In real usage, the onupdate=utc_now would update this
         assert setting.value == "new_value"

--- a/backend/tests/unit/test_overlap_prevention.py
+++ b/backend/tests/unit/test_overlap_prevention.py
@@ -17,6 +17,7 @@ from app.overlap_prevention import (
     clear_stale_locks
 )
 from app.models import ApplicationSettings
+from app.time_utils import utc_now
 
 
 class TestSchedulerLock:
@@ -57,8 +58,8 @@ class TestSchedulerLock:
             key="test_job_running",
             value="true",
             description="Test lock flag",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db_session.add(flag)
         db_session.commit()
@@ -111,7 +112,7 @@ class TestSchedulerLock:
 
     def test_lock_updates_last_run_timestamp(self, db_session):
         """Test that last_run timestamp is updated on lock acquisition."""
-        before_time = datetime.utcnow()
+        before_time = utc_now()
 
         with scheduler_lock(db_session, "test_job"):
             # Check last_run timestamp
@@ -188,13 +189,13 @@ class TestUpdateLastRunTimestamp:
     def test_updates_existing_timestamp(self, db_session):
         """Test that existing timestamp is updated."""
         # Create initial timestamp
-        old_time = (datetime.utcnow() - timedelta(hours=1)).isoformat()
+        old_time = (utc_now() - timedelta(hours=1)).isoformat()
         initial_setting = ApplicationSettings(
             key="test_job_last_run",
             value=old_time,
             description="Last run timestamp",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db_session.add(initial_setting)
         db_session.commit()
@@ -212,9 +213,9 @@ class TestUpdateLastRunTimestamp:
 
     def test_timestamp_is_recent(self, db_session):
         """Test that timestamp is within reasonable time."""
-        before = datetime.utcnow()
+        before = utc_now()
         _update_last_run_timestamp(db_session, "test_job")
-        after = datetime.utcnow()
+        after = utc_now()
 
         timestamp_setting = db_session.query(ApplicationSettings).filter(
             ApplicationSettings.key == "test_job_last_run"
@@ -231,7 +232,7 @@ class TestClearStaleLocks:
     def test_clears_stale_lock(self, db_session):
         """Test that stale locks are cleared."""
         # Create a stale lock (3 hours old)
-        stale_time = datetime.utcnow() - timedelta(hours=3)
+        stale_time = utc_now() - timedelta(hours=3)
 
         stale_flag = ApplicationSettings(
             key="stale_job_running",
@@ -268,7 +269,7 @@ class TestClearStaleLocks:
     def test_does_not_clear_fresh_lock(self, db_session):
         """Test that fresh locks are not cleared."""
         # Create a fresh lock (30 minutes old)
-        fresh_time = datetime.utcnow() - timedelta(minutes=30)
+        fresh_time = utc_now() - timedelta(minutes=30)
 
         fresh_flag = ApplicationSettings(
             key="fresh_job_running",
@@ -304,7 +305,7 @@ class TestClearStaleLocks:
 
     def test_clears_multiple_stale_locks(self, db_session):
         """Test that multiple stale locks are cleared."""
-        stale_time = datetime.utcnow() - timedelta(hours=3)
+        stale_time = utc_now() - timedelta(hours=3)
 
         # Create 3 stale locks
         for i in range(1, 4):
@@ -336,7 +337,7 @@ class TestClearStaleLocks:
 
     def test_handles_missing_last_run(self, db_session):
         """Test that locks without last_run timestamp are cleared based on updated_at."""
-        stale_time = datetime.utcnow() - timedelta(hours=3)
+        stale_time = utc_now() - timedelta(hours=3)
 
         # Create lock without last_run timestamp
         flag = ApplicationSettings(
@@ -371,7 +372,7 @@ class TestClearStaleLocks:
     def test_custom_max_age(self, db_session):
         """Test clear_stale_locks with custom max_age_hours."""
         # Create lock that is 1.5 hours old
-        old_time = datetime.utcnow() - timedelta(hours=1, minutes=30)
+        old_time = utc_now() - timedelta(hours=1, minutes=30)
 
         flag = ApplicationSettings(
             key="custom_age_job_running",

--- a/backend/tests/unit/test_scheduled_download_job.py
+++ b/backend/tests/unit/test_scheduled_download_job.py
@@ -20,6 +20,7 @@ from app.scheduled_download_job import (
 )
 from app.models import Channel, DownloadHistory, ApplicationSettings, Download
 from app.overlap_prevention import JobAlreadyRunningError
+from app.time_utils import utc_now
 
 
 class TestScheduledDownloadJob:
@@ -342,7 +343,7 @@ class TestUpdateJobStatistics:
             "successful_channels": 4,
             "failed_channels": 1,
             "total_videos": 20,
-            "start_time": datetime.utcnow()
+            "start_time": utc_now()
         }
 
         _update_job_statistics(summary, db_session)
@@ -369,8 +370,8 @@ class TestUpdateJobStatistics:
             key="scheduler_total_channels_last_run",
             value="3",
             description="Test stat",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utc_now(),
+            updated_at=utc_now()
         )
         db_session.add(old_stat)
         db_session.commit()
@@ -381,7 +382,7 @@ class TestUpdateJobStatistics:
             "successful_channels": 8,
             "failed_channels": 2,
             "total_videos": 40,
-            "start_time": datetime.utcnow()
+            "start_time": utc_now()
         }
 
         _update_job_statistics(summary, db_session)
@@ -397,7 +398,7 @@ class TestUpdateJobStatistics:
         """Test that database errors don't crash the job."""
         summary = {
             "total_channels": 5,
-            "start_time": datetime.utcnow()
+            "start_time": utc_now()
         }
 
         # Force database to fail

--- a/frontend/src/__tests__/components/ActiveDownloads.test.tsx
+++ b/frontend/src/__tests__/components/ActiveDownloads.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ActiveDownloads } from '../../components/ActiveDownloads'
+
+/**
+ * ActiveDownloads Tests (US-010: Active Download Progress)
+ *
+ * Verifies:
+ * - Renders nothing when no downloads are active
+ * - Renders progress bars with title, channel, percent, speed, and ETA
+ * - Shows the processing state after the transfer completes
+ */
+
+const activeDownload = {
+  video_id: 'vid123',
+  channel_id: 1,
+  channel_name: 'Test Channel',
+  title: 'Big Video',
+  status: 'downloading',
+  percent: 42.5,
+  downloaded_bytes: 425 * 1024 * 1024,
+  total_bytes: 1000 * 1024 * 1024,
+  speed: 5 * 1024 * 1024,
+  eta_seconds: 115,
+}
+
+function mockActive(active: object[]) {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ active, count: active.length }),
+    })
+  ) as jest.Mock
+}
+
+describe('ActiveDownloads Component', () => {
+  afterEach(() => {
+    ;(global.fetch as jest.Mock).mockReset()
+  })
+
+  it('renders nothing when idle', async () => {
+    mockActive([])
+
+    const { container } = render(<ActiveDownloads />)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/v1/downloads/active')
+    })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders progress details for an active download', async () => {
+    mockActive([activeDownload])
+
+    render(<ActiveDownloads />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Downloading (1)')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Big Video')).toBeInTheDocument()
+    expect(screen.getByText('43%')).toBeInTheDocument()
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '42.5')
+    // Channel, sizes, speed, and ETA are combined in the detail line
+    expect(screen.getByText(/Test Channel/)).toBeInTheDocument()
+    expect(screen.getByText(/425\.0 MB of 1000\.0 MB/)).toBeInTheDocument()
+    expect(screen.getByText(/5\.0 MB\/s/)).toBeInTheDocument()
+    expect(screen.getByText(/1m 55s left/)).toBeInTheDocument()
+  })
+
+  it('shows processing state when transfer is finished', async () => {
+    mockActive([{ ...activeDownload, status: 'processing', percent: 100 }])
+
+    render(<ActiveDownloads />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Processing')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/__tests__/components/ChannelStatusDashboard.test.tsx
+++ b/frontend/src/__tests__/components/ChannelStatusDashboard.test.tsx
@@ -87,6 +87,9 @@ function mockFetchImplementation(dashboard = baseDashboard) {
     if (url.startsWith('/api/v1/scheduler/status')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(schedulerStatus) })
     }
+    if (url.startsWith('/api/v1/downloads/active')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], count: 0 }) })
+    }
     if (url.startsWith('/api/v1/channels/') && options?.method === 'PUT') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
     }

--- a/frontend/src/__tests__/components/Settings.test.tsx
+++ b/frontend/src/__tests__/components/Settings.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { Settings } from '../../components/Settings'
+
+/**
+ * Settings Tests — focused on the newer sections:
+ * - Default Video Quality (US-015)
+ * - YouTube cookies health display
+ * - Failure notification configuration (Apprise)
+ *
+ * URL-dispatched fetch mocking covers the many independent fetches the
+ * settings page performs on mount.
+ */
+
+const jsonResponse = (body: unknown, ok = true) => ({ ok, json: () => Promise.resolve(body) })
+
+let cookieStatusResponse: object
+let notificationsResponse: object
+
+function installFetchMock() {
+  ;(global.fetch as jest.Mock).mockImplementation((url: string, options?: RequestInit) => {
+    if (url.startsWith('/api/v1/settings/default-video-limit')) {
+      return Promise.resolve(jsonResponse({
+        limit: 10,
+        description: 'Default limit',
+        updated_at: '2026-01-01T00:00:00',
+      }))
+    }
+    if (url.startsWith('/api/v1/settings/default-quality')) {
+      if (options?.method === 'PUT') {
+        return Promise.resolve(jsonResponse({
+          quality: JSON.parse(String(options.body)).quality,
+          description: 'Default quality',
+          updated_at: '2026-01-01T00:00:00',
+        }))
+      }
+      return Promise.resolve(jsonResponse({
+        quality: '1080p',
+        description: 'Default quality',
+        updated_at: '2026-01-01T00:00:00',
+      }))
+    }
+    if (url.startsWith('/api/v1/settings/cookies-status')) {
+      return Promise.resolve(jsonResponse(cookieStatusResponse))
+    }
+    if (url.startsWith('/api/v1/settings/notifications/test')) {
+      return Promise.resolve(jsonResponse({ message: 'Test notification sent' }))
+    }
+    if (url.startsWith('/api/v1/settings/notifications')) {
+      if (options?.method === 'PUT') {
+        const body = JSON.parse(String(options.body))
+        return Promise.resolve(jsonResponse({ url: body.url, enabled: !!body.url }))
+      }
+      return Promise.resolve(jsonResponse(notificationsResponse))
+    }
+    if (url.startsWith('/api/v1/settings/nfo')) {
+      return Promise.resolve(jsonResponse({ enabled: true, overwrite_existing: false }))
+    }
+    if (url.startsWith('/api/v1/scheduler/status')) {
+      return Promise.resolve(jsonResponse({
+        scheduler_running: false,
+        scheduler_enabled: true,
+        cron_schedule: '0 0 * * *',
+        next_run: null,
+        last_run: null,
+        download_job_active: true,
+        total_jobs: 1,
+      }))
+    }
+    if (url.startsWith('/api/v1/channels')) {
+      return Promise.resolve(jsonResponse({ channels: [], total: 0, enabled: 0 }))
+    }
+    return Promise.resolve(jsonResponse({}))
+  })
+}
+
+describe('Settings Component - quality, cookies, notifications', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn() as jest.Mock
+    cookieStatusResponse = { present: true, age_days: 3, stale: false }
+    notificationsResponse = { url: '', enabled: false }
+    installFetchMock()
+  })
+
+  afterEach(() => {
+    ;(global.fetch as jest.Mock).mockReset()
+  })
+
+  it('loads and saves the default video quality (US-015)', async () => {
+    render(<Settings />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Default Video Quality')).toHaveValue('1080p')
+    })
+
+    fireEvent.change(screen.getByLabelText('Default Video Quality'), { target: { value: '720p' } })
+    const saveButtons = screen.getAllByRole('button', { name: /^save$/i })
+    // Second Save button belongs to the quality section (first is limit)
+    fireEvent.click(saveButtons[1])
+
+    await waitFor(() => {
+      const putCall = (global.fetch as jest.Mock).mock.calls.find(
+        (c) => String(c[0]).includes('default-quality') && c[1]?.method === 'PUT'
+      )
+      expect(putCall).toBeDefined()
+      expect(JSON.parse(putCall[1].body)).toEqual({ quality: '720p' })
+    })
+  })
+
+  it('shows healthy cookie status', async () => {
+    render(<Settings />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cookies file present \(3 days old\)/)).toBeInTheDocument()
+    })
+  })
+
+  it('warns when cookies are stale or missing', async () => {
+    cookieStatusResponse = { present: true, age_days: 45, stale: true }
+
+    render(<Settings />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/45 days old — YouTube sessions typically expire/)).toBeInTheDocument()
+    })
+  })
+
+  it('saves a notification URL and enables the Test button', async () => {
+    render(<Settings />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Failure Notifications/)).toBeInTheDocument()
+    })
+
+    // Test button disabled until a URL is saved
+    expect(screen.getByRole('button', { name: /^test$/i })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText(/Failure Notifications/), {
+      target: { value: 'ntfy://ntfy.sh/my-topic' },
+    })
+    // Buttons named exactly "Save": limit, quality, notifications (in order)
+    const saveButtons = screen.getAllByRole('button', { name: /^save$/i })
+    fireEvent.click(saveButtons[saveButtons.length - 1])
+
+    await waitFor(() => {
+      const putCall = (global.fetch as jest.Mock).mock.calls.find(
+        (c) => String(c[0]) === '/api/v1/settings/notifications' && c[1]?.method === 'PUT'
+      )
+      expect(putCall).toBeDefined()
+      expect(JSON.parse(putCall[1].body)).toEqual({ url: 'ntfy://ntfy.sh/my-topic' })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Notifications enabled')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /^test$/i })).not.toBeDisabled()
+    })
+  })
+})

--- a/frontend/src/components/ActiveDownloads.tsx
+++ b/frontend/src/components/ActiveDownloads.tsx
@@ -1,0 +1,123 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { DownloadIcon, Loader2Icon } from 'lucide-react'
+
+/**
+ * ActiveDownloads - Live progress panel for in-flight downloads (US-010)
+ *
+ * Polls /api/v1/downloads/active every 2 seconds and renders a progress bar
+ * per active download (title, channel, percent, speed, ETA). Renders nothing
+ * when idle, so it costs no screen space outside download windows.
+ *
+ * Polling (not SSE) is deliberate: the Next.js pages-router API proxy
+ * buffers streaming responses, and a 2s poll of an in-memory snapshot is
+ * effectively real-time for a personal media server.
+ */
+
+interface ActiveDownload {
+  video_id: string
+  channel_id: number
+  channel_name: string
+  title: string
+  status: string
+  percent: number
+  downloaded_bytes: number
+  total_bytes?: number | null
+  speed?: number | null
+  eta_seconds?: number | null
+}
+
+const POLL_INTERVAL_MS = 2000
+
+function formatBytes(bytes?: number | null): string {
+  if (!bytes || bytes <= 0) return ''
+  const units = ['B', 'KB', 'MB', 'GB']
+  let size = bytes
+  let unitIndex = 0
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex++
+  }
+  return `${size.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`
+}
+
+function formatSpeed(bytesPerSecond?: number | null): string {
+  if (!bytesPerSecond) return ''
+  return `${formatBytes(bytesPerSecond)}/s`
+}
+
+function formatEta(seconds?: number | null): string {
+  if (seconds == null || seconds < 0) return ''
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  const minutes = Math.floor(seconds / 60)
+  return `${minutes}m ${Math.round(seconds % 60)}s`
+}
+
+export function ActiveDownloads() {
+  const [downloads, setDownloads] = useState<ActiveDownload[]>([])
+
+  const poll = useCallback(async () => {
+    try {
+      const response = await fetch('/api/v1/downloads/active')
+      if (response.ok) {
+        const data = await response.json()
+        setDownloads(data.active || [])
+      }
+    } catch {
+      // Transient poll failures are invisible; next poll retries
+    }
+  }, [])
+
+  useEffect(() => {
+    poll()
+    const interval = setInterval(poll, POLL_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [poll])
+
+  if (downloads.length === 0) return null
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-5" data-testid="active-downloads">
+      <div className="flex items-center mb-3">
+        <DownloadIcon className="h-5 w-5 mr-2 text-red-600 animate-pulse" />
+        <h3 className="font-semibold text-gray-900">
+          Downloading ({downloads.length})
+        </h3>
+      </div>
+      <div className="space-y-3">
+        {downloads.map((download) => (
+          <div key={download.video_id}>
+            <div className="flex items-center justify-between mb-1">
+              <p className="text-sm font-medium text-gray-900 truncate mr-2" title={download.title}>
+                {download.title}
+              </p>
+              <span className="text-xs text-gray-500 whitespace-nowrap">
+                {download.status === 'processing' ? (
+                  <span className="inline-flex items-center">
+                    <Loader2Icon className="h-3 w-3 mr-1 animate-spin" />
+                    Processing
+                  </span>
+                ) : (
+                  `${download.percent.toFixed(0)}%`
+                )}
+              </span>
+            </div>
+            <div className="w-full bg-gray-100 rounded-full h-2" role="progressbar"
+              aria-valuenow={download.percent} aria-valuemin={0} aria-valuemax={100}
+              aria-label={`Download progress for ${download.title}`}>
+              <div
+                className={`h-2 rounded-full transition-all ${download.status === 'processing' ? 'bg-yellow-500' : 'bg-red-600'}`}
+                style={{ width: `${Math.min(100, download.percent)}%` }}
+              />
+            </div>
+            <p className="text-xs text-gray-500 mt-1">
+              {download.channel_name}
+              {download.total_bytes ? ` · ${formatBytes(download.downloaded_bytes)} of ${formatBytes(download.total_bytes)}` : ''}
+              {download.speed ? ` · ${formatSpeed(download.speed)}` : ''}
+              {download.eta_seconds != null ? ` · ${formatEta(download.eta_seconds)} left` : ''}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ChannelStatusDashboard.tsx
+++ b/frontend/src/components/ChannelStatusDashboard.tsx
@@ -15,6 +15,7 @@ import {
   CalendarClockIcon,
 } from 'lucide-react'
 import { SchedulerStatusWidget } from './SchedulerStatusWidget'
+import { ActiveDownloads } from './ActiveDownloads'
 
 /**
  * ChannelStatusDashboard Component - Landing page with channel health + storage
@@ -193,6 +194,9 @@ export function ChannelStatusDashboard({
   return (
     <div className="space-y-6 max-w-5xl mx-auto">
       <SchedulerStatusWidget onNavigateToSettings={onNavigateToSettings} />
+
+      {/* Live download progress (US-010) - renders nothing when idle */}
+      <ActiveDownloads />
 
       {/* Storage warning banner (US-012: warn at >= 80% capacity) */}
       {data?.disk?.warning && (

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -86,6 +86,19 @@ export function Settings() {
   const [originalQuality, setOriginalQuality] = useState<string>('best')
   const [qualitySaving, setQualitySaving] = useState<boolean>(false)
 
+  // Cookie health + notification settings (operational hardening)
+  const [cookieStatus, setCookieStatus] = useState<{
+    present: boolean
+    age_days?: number | null
+    stale?: boolean
+  } | null>(null)
+  const [notificationUrl, setNotificationUrl] = useState<string>('')
+  const [originalNotificationUrl, setOriginalNotificationUrl] = useState<string>('')
+  const [notifSaving, setNotifSaving] = useState<boolean>(false)
+  const [notifTesting, setNotifTesting] = useState<boolean>(false)
+  const [notifMessage, setNotifMessage] = useState<string>('')
+  const [notifError, setNotifError] = useState<string>('')
+
   // Scheduler state (Story 007)
   const [schedulerStatus, setSchedulerStatus] = useState<SchedulerStatus | null>(null)
   const [cronExpression, setCronExpression] = useState<string>('0 0 * * *')
@@ -206,6 +219,72 @@ export function Settings() {
       setError(err instanceof Error ? err.message : 'Failed to save default quality')
     } finally {
       setQualitySaving(false)
+    }
+  }
+
+  /** Fetch cookie file health (non-critical; UI degrades silently). */
+  const fetchCookieStatus = async () => {
+    try {
+      const response = await fetch('/api/v1/settings/cookies-status')
+      if (response.ok) setCookieStatus(await response.json())
+    } catch (err) {
+      console.error('Error fetching cookie status:', err)
+    }
+  }
+
+  /** Fetch the configured notification URL (non-critical). */
+  const fetchNotificationSettings = async () => {
+    try {
+      const response = await fetch('/api/v1/settings/notifications')
+      if (response.ok) {
+        const data = await response.json()
+        setNotificationUrl(data.url || '')
+        setOriginalNotificationUrl(data.url || '')
+      }
+    } catch (err) {
+      console.error('Error fetching notification settings:', err)
+    }
+  }
+
+  /** Save (or clear, when blank) the Apprise notification URL. */
+  const saveNotificationSettings = async () => {
+    setNotifSaving(true)
+    setNotifError('')
+    setNotifMessage('')
+    try {
+      const response = await fetch('/api/v1/settings/notifications', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: notificationUrl.trim() }),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.detail || 'Failed to save notification settings')
+      setOriginalNotificationUrl(data.url || '')
+      setNotificationUrl(data.url || '')
+      setNotifMessage(data.enabled ? 'Notifications enabled' : 'Notifications disabled')
+      setTimeout(() => setNotifMessage(''), 3000)
+    } catch (err) {
+      setNotifError(err instanceof Error ? err.message : 'Failed to save notification settings')
+    } finally {
+      setNotifSaving(false)
+    }
+  }
+
+  /** Send a test notification to the saved URL. */
+  const sendTestNotification = async () => {
+    setNotifTesting(true)
+    setNotifError('')
+    setNotifMessage('')
+    try {
+      const response = await fetch('/api/v1/settings/notifications/test', { method: 'POST' })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.detail || 'Test notification failed')
+      setNotifMessage('Test notification sent')
+      setTimeout(() => setNotifMessage(''), 3000)
+    } catch (err) {
+      setNotifError(err instanceof Error ? err.message : 'Test notification failed')
+    } finally {
+      setNotifTesting(false)
     }
   }
 
@@ -580,7 +659,9 @@ export function Settings() {
       fetchDefaultQuality(),
       fetchSchedulerStatus(),
       checkChannelsExist(),
-      fetchNfoSettings()
+      fetchNfoSettings(),
+      fetchCookieStatus(),
+      fetchNotificationSettings()
     ])
   }, [])
 
@@ -1079,6 +1160,80 @@ export function Settings() {
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-gray-200 my-8"></div>
+
+        {/* System Health & Alerts (operational hardening) */}
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-lg font-medium text-gray-900 mb-4">
+              System Health &amp; Alerts
+            </h3>
+
+            {/* YouTube cookies status */}
+            <div className={`p-3 rounded-md border mb-4 ${
+              !cookieStatus || !cookieStatus.present || cookieStatus.stale
+                ? 'bg-yellow-50 border-yellow-200'
+                : 'bg-green-50 border-green-200'
+            }`}>
+              <p className="text-sm font-medium text-gray-800">YouTube Cookies</p>
+              <p className="text-sm text-gray-600 mt-0.5">
+                {!cookieStatus
+                  ? 'Checking cookie file...'
+                  : !cookieStatus.present
+                    ? 'No cookies file found. Downloads may be blocked by YouTube bot detection.'
+                    : cookieStatus.stale
+                      ? `Cookies file is ${cookieStatus.age_days} days old — YouTube sessions typically expire within weeks. Consider refreshing it.`
+                      : `Cookies file present (${cookieStatus.age_days} day${cookieStatus.age_days === 1 ? '' : 's'} old).`}
+              </p>
+            </div>
+
+            {/* Failure notifications */}
+            <label htmlFor="notificationUrl" className="block text-sm font-medium text-gray-700 mb-2">
+              Failure Notifications (Apprise URL)
+            </label>
+            <div className="flex items-start space-x-4">
+              <div className="flex-1">
+                <input
+                  type="text"
+                  id="notificationUrl"
+                  value={notificationUrl}
+                  onChange={(e) => setNotificationUrl(e.target.value)}
+                  placeholder="ntfy://ntfy.sh/my-topic or discord://webhook_id/token"
+                  disabled={notifSaving}
+                  className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+                <p className="mt-1 text-sm text-gray-500">
+                  Notified when scheduled downloads fail. Leave blank to disable.
+                  Supports any <a className="underline" href="https://github.com/caronc/apprise" target="_blank" rel="noopener noreferrer">Apprise</a> service.
+                </p>
+              </div>
+              <button
+                onClick={saveNotificationSettings}
+                disabled={notificationUrl === originalNotificationUrl || notifSaving}
+                className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {notifSaving ? 'Saving...' : 'Save'}
+              </button>
+              <button
+                onClick={sendTestNotification}
+                disabled={!originalNotificationUrl || notifTesting}
+                title={originalNotificationUrl ? 'Send a test notification' : 'Save a URL first'}
+                className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md shadow-sm text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {notifTesting ? 'Sending...' : 'Test'}
+              </button>
+            </div>
+
+            {notifMessage && (
+              <p className="mt-2 text-sm text-green-700">{notifMessage}</p>
+            )}
+            {notifError && (
+              <p className="mt-2 text-sm text-red-700">{notifError}</p>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/api/v1/settings/cookies-status.ts
+++ b/frontend/src/pages/api/v1/settings/cookies-status.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { fetchBackend, formatApiError } from '@/lib/apiClient'
+
+/** Proxy for the YouTube cookies file health status. */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET'])
+    return res.status(405).json({ error: `Method ${req.method} not allowed` })
+  }
+  try {
+    const { status, data } = await fetchBackend('/api/v1/settings/cookies-status', {
+      method: 'GET',
+      operationType: 'standard',
+    })
+    res.status(status).json(data)
+  } catch (error) {
+    const errorResponse = formatApiError(error, 'Cookies status')
+    res.status(errorResponse.timedOut ? 504 : 500).json(errorResponse)
+  }
+}

--- a/frontend/src/pages/api/v1/settings/notifications/index.ts
+++ b/frontend/src/pages/api/v1/settings/notifications/index.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { fetchBackend, formatApiError } from '@/lib/apiClient'
+
+/** Proxy for reading/updating the Apprise notification URL. */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET' && req.method !== 'PUT') {
+    res.setHeader('Allow', ['GET', 'PUT'])
+    return res.status(405).json({ error: `Method ${req.method} not allowed` })
+  }
+  try {
+    const { status, data } = await fetchBackend('/api/v1/settings/notifications', {
+      method: req.method,
+      body: req.method === 'PUT' ? req.body : undefined,
+      operationType: 'standard',
+    })
+    res.status(status).json(data)
+  } catch (error) {
+    const errorResponse = formatApiError(error, 'Notification settings')
+    res.status(errorResponse.timedOut ? 504 : 500).json(errorResponse)
+  }
+}

--- a/frontend/src/pages/api/v1/settings/notifications/test.ts
+++ b/frontend/src/pages/api/v1/settings/notifications/test.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { fetchBackend, formatApiError } from '@/lib/apiClient'
+
+/** Proxy for sending a test notification. */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).json({ error: `Method ${req.method} not allowed` })
+  }
+  try {
+    const { status, data } = await fetchBackend('/api/v1/settings/notifications/test', {
+      method: 'POST',
+      operationType: 'standard',
+    })
+    res.status(status).json(data)
+  } catch (error) {
+    const errorResponse = formatApiError(error, 'Test notification')
+    res.status(errorResponse.timedOut ? 504 : 500).json(errorResponse)
+  }
+}


### PR DESCRIPTION
## Summary

Three remaining backlog items in one stacked PR (each was developed and tested as its own commit): **real-time download progress (US-010)**, **operational hardening**, and the **deprecated-datetime migration**.

### Real-time download progress (US-010)

- New thread-safe in-memory `DownloadProgressStore` fed by yt-dlp progress hooks. Downloads register on start and always deregister on every exit path; a hook failure can never break a download.
- `GET /api/v1/downloads/active` — lightweight snapshot for polling. `GET /api/v1/downloads/progress/stream` — true SSE stream for direct API consumers.
- New `ActiveDownloads` dashboard panel: polls every 2s, shows per-download progress bars (title, channel, percent, size, speed, ETA) and a processing state during merge/embed; renders nothing when idle. The UI polls rather than consuming SSE because the Next.js pages-router proxy buffers streaming responses — documented in the code.

### Operational hardening

- **Deep `/health`**: yt-dlp importability/version, ffmpeg/ffprobe presence, media-volume capacity (problem at ≥90%), scheduler liveness (enabled but silent >48h = stale). Returns `healthy`/`degraded` with an explicit `problems` list; always 200 so container healthchecks measure reachability.
- **Cookie health**: `GET /settings/cookies-status` (presence, size, age, stale at 30 days) + a Settings-page card — expired cookies are this app's top silent breakage source.
- **Failure notifications** via Apprise (already in requirements): `notification_service` with URL validation, `GET/PUT /settings/notifications` + `POST .../test`, wired into scheduled-job failure paths. Strictly best-effort — notification errors never affect downloads. Settings page gains URL input with Save/Test.
- **Recent logs**: `GET /logs/recent` serves the last 500 records from an in-memory ring-buffer handler (US-014 complement to docker logs).
- Documented the sequential-cross-thread session pattern in `database.py` (suggested by #43's review).

### Datetime migration

- New `app/time_utils` module (`utc_now()` / `utc_from_timestamp()`) sources time from the timezone-aware clock while preserving the naive-UTC storage convention end to end (SQLite text storage, offset-less serialization, frontend Z-appending) — the convention is now documented in one place.
- All 73 app and 54 test call sites of deprecated `datetime.utcnow()`/`utcfromtimestamp()` migrated, including model column defaults.
- Pydantic class-based `Config` → `ConfigDict` (clears the PydanticDeprecatedSince20 warnings).
- The suite now passes under `-W error::DeprecationWarning` except two manual tests whose warnings originate inside yt-dlp itself.

## Testing

- **Backend: 355 passed, 0 failed.** New: 9 progress tests (store lifecycle, hook translation, missing totals, error isolation, endpoint), 14 hardening tests (health shape + staleness, cookie states, notification settings/validation/dispatch guards, ring buffer + endpoint). Health tests updated to the healthy/degraded contract.
- **Frontend: 78 passed, 0 failed; tsc clean.** New: 3 ActiveDownloads tests + 4 Settings tests (default-quality save — closing the gap noted in #43's review — cookie states, notification save/test flow).

https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd)_