### PR TITLE
docs: bring all feature documentation up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,18 +53,30 @@ docker compose -f docker-compose.dev.yml up
 
 ## Configuration
 
-Create a `config.yaml` file:
+Everything is configurable from the **web UI** — no file editing required. A
+`config.yaml` is written to `data/config.yaml` and kept in sync with the
+database, so advanced users can also edit it directly:
 
 ```yaml
 channels:
   - url: "https://www.youtube.com/@ChannelName"
-    limit: 10
-    enabled: true
+    limit: 10                      # Videos to keep for this channel
+    enabled: true                  # Pause monitoring without removing
+    quality_preset: "best"         # best | 2160p | 1080p | 720p | 480p
+    schedule_override: "0 6 * * *" # Optional per-channel cron (omit to use global)
 
 settings:
-  schedule: "0 */6 * * *"  # Every 6 hours
-  media_dir: "/media"
+  default_video_limit: 10          # Applied to new channels
+  default_quality_preset: "best"   # Applied to new channels
+  cron_schedule: "0 */6 * * *"     # Global download schedule
+  scheduler_enabled: true
+  nfo_enabled: true                # Generate Jellyfin .nfo files
+  notification_url: ""             # Apprise URL for failure alerts (blank = off)
 ```
+
+> The database is the source of truth; the YAML file mirrors it for backup and
+> transparency. See [docs/configuration.md](docs/configuration.md) for the full
+> reference.
 
 ## File Organization
 
@@ -114,21 +126,21 @@ cd channelfinwatcher
 # Download compose file
 curl -O https://raw.githubusercontent.com/miguelarios/ChannelFinWatcher/main/docker-compose.yml
 
-# Edit for production use (IMPORTANT: change test paths and ports)
+# Optional: adjust TZ and host ports for your environment
 nano docker-compose.yml
-# Change:
-#   - ./test/data -> ./data
-#   - ./test/media -> ./media
-#   - ./test/temp -> ./temp
-#   - ports 3333:3000 -> 3000:3000 (or your preferred port)
-#   - ports 8001:8000 -> 8000:8000 (optional, for API access)
-#   - TZ to your timezone
+#   - TZ: set your timezone (default America/Chicago)
+#   - ports: 3333:3000 maps the web UI to host port 3333 (change as desired)
+#   - ports: 8001:8000 exposes the API/docs (optional)
 
 # Start the application
 docker compose up -d
 
-# Access web UI at http://localhost:3000
+# Access web UI at http://localhost:3333
 ```
+
+The shipped image is a **single container** that runs both the API (port 8000)
+and the web UI (port 3000) under supervisor, with `ffmpeg` and Node.js
+included. Volumes already point at `./data`, `./media`, and `./temp`.
 
 ### Directory Structure
 
@@ -140,19 +152,34 @@ docker compose up -d
 
 ## Architecture
 
-- **Backend**: FastAPI with SQLAlchemy, APScheduler, and WebSocket support
-- **Frontend**: NextJS with TypeScript, TailwindCSS, and React Query  
-- **Database**: SQLite for development, configurable for production
-- **Real-time**: WebSocket connections for live updates
-- **Deployment**: Multi-container Docker setup with persistent volumes
+- **Backend**: FastAPI with SQLAlchemy and APScheduler (SQLite-persisted jobs)
+- **Frontend**: NextJS (pages router) with TypeScript and TailwindCSS
+- **Database**: SQLite (schema managed by Alembic migrations)
+- **Live updates**: yt-dlp progress hooks → in-memory store → 1s polling in the
+  UI, plus a Server-Sent Events stream for API consumers
+- **Deployment**: single production container (supervisor runs API + UI);
+  multi-container Docker Compose for local development
 
-## Development Resources
+See the [Technical Design Document](docs/tdd.md) for the full architecture and
+[docs/api-reference.md](docs/api-reference.md) for the REST API.
 
-See [CLAUDE.md](CLAUDE.md) for development workflow and [docs/](docs/) for detailed requirements.
+## Documentation
 
-## Status
+- **[User Guide](docs/user-guide.md)** — every feature and how to use it
+- **[Configuration Reference](docs/configuration.md)** — all settings (web UI, YAML, env)
+- **[API Reference](docs/api-reference.md)** — every REST endpoint
+- **[Deployment Guide](docs/DEPLOYMENT.md)** — production setup and updates
+- **[Technical Design](docs/tdd.md)** — architecture and internals
+- **[CLAUDE.md](CLAUDE.md)** — development workflow
 
-🚧 **In Development** - Core functionality being implemented
+## Roadmap
+
+Ideas not yet implemented (contributions welcome):
+
+- WebSocket transport for live updates (currently polling + SSE)
+- Authentication / multi-user support (currently single-user, trusted-LAN)
+- Storage-trend charts and disk-full projections
+- Bandwidth / concurrent-download limits
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -89,7 +89,10 @@ channelfinwatcher/
 ├── media/                         # Downloaded videos (REQUIRED)
 │   └── [Channel Name] [ID]/
 │       └── YYYY/
-│           └── [Channel] - [Date] - [Title] [ID].mp4
+│           └── [Channel] - [Date] - [Title] [ID]/
+│               ├── [Channel] - [Date] - [Title] [ID].mkv
+│               ├── [Channel] - [Date] - [Title] [ID].info.json
+│               └── [Channel] - [Date] - [Title] [ID].nfo   # Jellyfin metadata
 ├── temp/                          # Download staging (REQUIRED)
 │   └── [temporary download files]
 └── docker-compose.prod.yml        # Your deployment configuration
@@ -116,6 +119,12 @@ channelfinwatcher/
 - Storage: **Fast SSD highly recommended** for download performance
 
 ## Configuration
+
+> This guide covers **container/deployment** configuration (Docker, volumes,
+> ports, timezone). For **application** settings — video limits, quality presets,
+> schedules, notifications, cookies — see the
+> [Configuration Reference](configuration.md). Almost all of those are managed
+> from the web UI's **Settings** page.
 
 ### Basic Configuration (docker-compose.yml)
 
@@ -578,8 +587,22 @@ crontab -e
 The container includes built-in health checks:
 
 ```bash
-# Check health status
+# Check Docker's view of health status
 docker inspect channelfinwatcher | grep -A 10 Health
+```
+
+The application also exposes a **deep health endpoint** that reports more than
+reachability — database, yt-dlp, ffmpeg, disk capacity, and scheduler liveness:
+
+```bash
+curl http://localhost:8000/health | jq
+# "status" is "healthy" or "degraded"; "problems" lists any issues
+```
+
+Recent application logs are available without a shell into the container:
+
+```bash
+curl "http://localhost:8000/api/v1/logs/recent?limit=50&level=WARNING" | jq
 ```
 
 ### Resource Usage

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,47 @@
+# ChannelFinWatcher Documentation
+
+Start here to find the right document.
+
+## For users
+- **[User Guide](user-guide.md)** — every feature and how to use it (dashboard,
+  channels, history, settings, downloads, cookies, notifications, troubleshooting).
+- **[Configuration Reference](configuration.md)** — all settings and where they
+  live (web UI, `config.yaml`, environment variables).
+- **[Deployment Guide](DEPLOYMENT.md)** — production install, volumes, ports,
+  updates, backups.
+
+## For developers / integrators
+- **[API Reference](api-reference.md)** — every REST endpoint (also live at
+  `/docs` and `/redoc` on a running instance).
+- **[Technical Design Document](tdd.md)** — architecture, data model, algorithms,
+  and future roadmap.
+- **[Development Guide](development-guide.md)** — local dev workflow and tooling.
+- **[Testing Guide](testing-guide.md)** — running and writing tests.
+- **[Code Documentation Guide](code-documentation-guide.md)** — docstring/comment
+  standards.
+- **[CI/CD Explained](CI-CD-EXPLAINED.md)** — the pipeline.
+
+## Product & planning
+- **[PRD](prd.md)** — product requirements and goals.
+- **[User Stories](stories/)** — original per-feature specs. Where the shipped
+  implementation diverged from the plan, the story carries an **as-built note**
+  at the top.
+- **[Tech Docs](tech-docs/)** — focused technical notes (download behavior,
+  metadata spec).
+
+## Feature → documentation map
+
+| Feature | Where it's documented |
+|---------|----------------------|
+| Adding & managing channels | [User Guide → Channels](user-guide.md#channels) |
+| Status dashboard | [User Guide → Dashboard](user-guide.md#dashboard) |
+| Download history & retry | [User Guide → History](user-guide.md#history) |
+| Live download progress | [User Guide → Live progress](user-guide.md#live-progress) |
+| Quality presets | [Configuration → Quality presets](configuration.md#quality-presets) |
+| Scheduling (global + per-channel) | [Configuration → Scheduling](configuration.md#scheduling) |
+| Failure notifications | [Configuration → Notifications](configuration.md#notifications) |
+| YouTube cookies | [User Guide → Cookies](user-guide.md#youtube-cookies) |
+| Storage monitoring | [User Guide → Dashboard](user-guide.md#dashboard) |
+| Health checks & logs | [API Reference → System](api-reference.md#system) |
+| REST API | [API Reference](api-reference.md) |
+| Architecture & internals | [TDD](tdd.md) |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,228 @@
+# API Reference
+
+ChannelFinWatcher exposes a REST API served by the FastAPI backend. This
+reference is generated from the current implementation (`backend/app/api.py`,
+`backend/main.py`).
+
+- **Base URL**: `http://<host>:8000`
+- **Prefix**: all endpoints below are under `/api/v1` **except** `/` and
+  `/health`, which are served at the root.
+- **Auth**: none. The app is designed for a single user on a trusted LAN.
+- **Interactive docs**: live Swagger UI at `/docs` and ReDoc at `/redoc`; the
+  raw OpenAPI schema is at `/api/v1/openapi.json`.
+- **Timestamps**: ISO-8601 **naive UTC** (no offset). Clients should treat them
+  as UTC.
+
+The bundled web UI does not call these directly; it calls thin Next.js proxy
+routes under `/api/v1/*` (in `frontend/src/pages/api/`) that forward here.
+
+---
+
+## System
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/` | API info and links to docs. |
+| `GET` | `/health` | Deep health check (see below). |
+| `GET` | `/api/v1/logs/recent` | Recent in-memory log records. |
+
+### `GET /health`
+Always returns **HTTP 200** (so container healthchecks measure reachability);
+the payload carries the diagnosis.
+
+```json
+{
+  "status": "healthy",              // or "degraded"
+  "problems": [],                    // human-readable issues when degraded
+  "service": "ChannelFinWatcher",
+  "version": "…",
+  "database": "connected",
+  "directories": { "...": { "exists": true, "writable": true } },
+  "tools": { "yt_dlp_version": "…", "ffmpeg": true, "ffprobe": true },
+  "disk": { "total_bytes": 0, "free_bytes": 0, "usage_percent": 42.0 },
+  "scheduler": { "enabled": true, "last_run": "…", "stale": false }
+}
+```
+`degraded` is reported for: DB unreachable, yt-dlp not importable, ffmpeg
+missing, disk ≥90% full, media volume unreadable, or scheduler enabled but
+silent for >48h.
+
+### `GET /api/v1/logs/recent`
+Query: `limit` (1–500, default 100), `level` (`DEBUG|INFO|WARNING|ERROR|CRITICAL`,
+returns that level and above). → `{ "logs": [{timestamp, level, logger, message}], "count": N }`
+
+---
+
+## Channels
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/channels` | List all channels with summary counts. |
+| `POST` | `/api/v1/channels` | Add a channel (extracts metadata, starts initial download). |
+| `GET` | `/api/v1/channels/{id}` | Get one channel. |
+| `PUT` | `/api/v1/channels/{id}` | Update channel settings (partial). |
+| `DELETE` | `/api/v1/channels/{id}` | Remove a channel (optionally its media). |
+| `POST` | `/api/v1/channels/{id}/refresh-metadata` | Re-fetch metadata + images. |
+| `POST` | `/api/v1/channels/{id}/reindex` | Sync DB with files on disk. |
+| `POST` | `/api/v1/channels/{id}/download` | Manually trigger a download run. |
+| `POST` | `/api/v1/channels/{id}/nfo/regenerate` | Regenerate NFO files for the channel. |
+
+### `POST /api/v1/channels`
+Body:
+```json
+{
+  "url": "https://www.youtube.com/@ChannelName",
+  "limit": 10,                 // optional; omit to use the global default
+  "enabled": true,             // optional (default true)
+  "quality_preset": "1080p",   // optional; omit to use the global default
+  "schedule_override": "0 6 * * *"  // optional per-channel cron
+}
+```
+`quality_preset` must be one of `best|2160p|1080p|720p|480p` (else 422). An
+invalid `schedule_override` cron returns 400. Duplicate channels return 400.
+
+### `PUT /api/v1/channels/{id}`
+Any subset of `name`, `limit`, `enabled`, `quality_preset`, `schedule_override`.
+Changing `schedule_override`/`enabled` re-syncs the per-channel scheduler job.
+
+### `DELETE /api/v1/channels/{id}`
+Query: `delete_media` (bool, default `false`). Deletes the DB record and,
+optionally, the channel's media directory.
+
+### `POST /api/v1/channels/{id}/reindex`
+Protected by an application-level lock; returns **409** if a reindex is already
+running. → stats `{ found, missing, added, skipped, errors }`.
+
+### `POST /api/v1/channels/{id}/download`
+Runs immediately when idle (**200**), or queues behind a running scheduled job
+(**202**, with queue `position`). 400 if the channel is disabled.
+
+---
+
+## Downloads
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/downloads` | Global download history across channels (filter + paginate). |
+| `GET` | `/api/v1/downloads/{id}` | One download record. |
+| `POST` | `/api/v1/downloads/{id}/retry` | Retry a failed download (resets its retry budget). |
+| `GET` | `/api/v1/downloads/active` | Snapshot of in-flight downloads with live progress. |
+| `GET` | `/api/v1/downloads/progress/stream` | Server-Sent Events stream of active-download snapshots. |
+| `GET` | `/api/v1/channels/{id}/downloads` | Per-channel download records (paginated). |
+| `GET` | `/api/v1/channels/{id}/download-history` | Per-channel run history. |
+
+### `GET /api/v1/downloads`
+Query: `channel_id`, `status` (`pending|downloading|completed|failed`),
+`limit` (1–200, default 50), `offset`. → `{ downloads: [...], total }`. Each item
+includes `channel_name`, `file_exists`, `deleted_at`, `retry_count`. An invalid
+`status` returns 400; an unknown `channel_id` returns an empty list (not 404).
+
+### `POST /api/v1/downloads/{id}/retry`
+Only valid for `failed` downloads (else 400); 400 if the channel is disabled;
+**409** if a scheduled job is running. Resets `retry_count`, re-attempts
+immediately (with within-run retries), and returns
+`{ success, error_message, download }`.
+
+### `GET /api/v1/downloads/active`
+`{ active: [{ video_id, channel_id, channel_name, title, status, percent,
+downloaded_bytes, total_bytes, speed, eta_seconds, started_at }], count }`.
+`status` is `starting` → `downloading` → `processing` (merge/embed).
+
+### `GET /api/v1/downloads/progress/stream`
+`text/event-stream`. Emits `data: {active, count}\n\n` once per second until the
+client disconnects. (The bundled UI polls `/downloads/active` instead, because
+the Next.js proxy buffers streaming responses.)
+
+---
+
+## Dashboard
+
+### `GET /api/v1/dashboard`
+Aggregated status for the dashboard in one round-trip:
+```json
+{
+  "disk": { "total_bytes": 0, "used_bytes": 0, "free_bytes": 0,
+            "usage_percent": 42.0, "warning": false },   // null if media dir unreadable
+  "totals": { "channels": 3, "enabled_channels": 2, "videos": 40, "storage_bytes": 0 },
+  "channels": [ {
+    "id": 1, "name": "…", "url": "…", "enabled": true, "limit": 10,
+    "quality_preset": "best", "schedule_override": null, "metadata_status": "completed",
+    "video_count": 8, "storage_bytes": 0, "last_check": "…",
+    "last_run_status": "completed", "last_run_date": "…", "last_run_error": null
+  } ],
+  "generated_at": "…"
+}
+```
+`warning` is `true` at ≥80% disk usage. Channels are sorted most-recently-checked
+first, never-checked last. Storage/counts come from the DB (completed downloads
+still on disk), not a filesystem walk.
+
+---
+
+## Settings
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET`/`PUT` | `/api/v1/settings/default-video-limit` | Default video limit for new channels (1–100). |
+| `GET`/`PUT` | `/api/v1/settings/default-quality` | Default quality preset for new channels. |
+| `GET`/`PUT` | `/api/v1/settings/nfo` | NFO generation settings (`enabled`, `overwrite_existing`). |
+| `GET` | `/api/v1/settings/cookies-status` | YouTube cookie file presence/age. |
+| `GET`/`PUT` | `/api/v1/settings/notifications` | Apprise notification URL. |
+| `POST` | `/api/v1/settings/notifications/test` | Send a test notification. |
+
+- **default-quality** `PUT` body `{ "quality": "1080p" }` — validated against the
+  preset list (422 otherwise). Applies to new channels only.
+- **cookies-status** → `{ present, path, size_bytes, modified_at, age_days, stale }`
+  (`stale` at ≥30 days).
+- **notifications** `PUT` body `{ "url": "ntfy://ntfy.sh/topic" }` — validated by
+  Apprise (400 if unrecognized); blank disables. `test` returns 400 if none is
+  configured, 502 if dispatch fails.
+
+Settings changes are mirrored to `config.yaml`.
+
+---
+
+## Scheduler
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/scheduler/status` | Current schedule, next/last run, job count. |
+| `POST` | `/api/v1/scheduler/schedule` | Set the global cron schedule. |
+| `PUT` | `/api/v1/scheduler/enable` | Enable/disable the scheduler. |
+| `GET` | `/api/v1/scheduler/validate` | Validate a cron expression (no save). |
+
+- **schedule** `POST` body `{ "cron_expression": "0 */6 * * *" }` — 5-field cron;
+  minimum interval 5 minutes. Returns next runs + a human-readable description.
+- **validate** query `?expression=…` → `{ valid, error, next_run, next_5_runs,
+  time_until_next, human_readable }`. Used for live validation in the UI (global
+  schedule and per-channel overrides).
+- **enable** `PUT` body `{ "enabled": true }`.
+
+Channels with a `schedule_override` run on their own per-channel jobs; all
+channels without one run on this global schedule.
+
+---
+
+## NFO (Jellyfin metadata)
+
+NFO files are generated automatically during downloads. These endpoints manage
+**backfill** for pre-existing libraries and manual regeneration.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/nfo/backfill/start` | Start backfilling NFO for channels missing it. |
+| `POST` | `/api/v1/nfo/backfill/pause` | Pause the backfill job. |
+| `POST` | `/api/v1/nfo/backfill/resume` | Resume the backfill job. |
+| `GET` | `/api/v1/nfo/backfill/status` | Backfill progress/state. |
+| `GET` | `/api/v1/nfo/backfill/needed` | Count of channels needing backfill. |
+| `POST` | `/api/v1/channels/{id}/nfo/regenerate` | Regenerate NFO for one channel. |
+
+---
+
+## Status codes
+
+- **200** success · **202** accepted/queued (manual download behind scheduler)
+- **400** validation error · **404** not found · **409** conflict (a lock is held)
+- **422** request-body schema validation (Pydantic) · **500** server error
+- **502** downstream failure (notification dispatch) · **504** upstream timeout
+  (returned by the frontend proxy for long operations)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,157 @@
+# Configuration Reference
+
+ChannelFinWatcher can be configured three ways, in order of how most users will
+interact with it:
+
+1. **Web UI** — the normal way. Everything below (except container paths) is
+   editable under **Settings** and per-channel controls.
+2. **`config.yaml`** — a mirror of the database written to `data/config.yaml`,
+   for backup, transparency, and advanced/bulk editing.
+3. **Environment variables** — container-level paths and runtime config.
+
+> **The database is the source of truth.** Settings changed in the UI are saved
+> to the DB and mirrored to `config.yaml`. If a setting is missing from the DB,
+> the value in `config.yaml` is used as a fallback; otherwise a built-in default
+> applies.
+
+---
+
+## Global settings
+
+These live in the database (`application_settings` table) and mirror to the
+`settings:` block of `config.yaml`. All are editable from the **Settings** page.
+
+| Setting | Default | Values | Purpose |
+|---------|---------|--------|---------|
+| `default_video_limit` | `10` | 1–100 | Videos kept per channel, applied to **new** channels. |
+| `default_quality_preset` | `best` | `best`, `2160p`, `1080p`, `720p`, `480p` | Quality applied to **new** channels. |
+| `cron_schedule` | `0 */6 * * *` | 5-field cron (≥5 min interval) | Global download schedule. |
+| `scheduler_enabled` | `true` | bool | Master switch for automatic downloads. |
+| `nfo_enabled` | `true` | bool | Generate Jellyfin `.nfo` files during downloads. |
+| `nfo_overwrite_existing` | `false` | bool | Overwrite existing NFO files on regeneration. |
+| `notification_url` | `""` | Apprise URL | Failure notifications; blank disables. See [Notifications](#notifications). |
+
+Changing a default (limit/quality) affects **new** channels only; existing
+channels keep their per-channel value.
+
+---
+
+## Per-channel settings
+
+Set when adding a channel and editable afterward (channel list / kebab menu).
+They mirror to the `channels:` block of `config.yaml`.
+
+| Field | Default | Values | Purpose |
+|-------|---------|--------|---------|
+| `url` | — | YouTube channel URL | `@handle`, `/channel/UC…`, `/c/…`, `/user/…` all accepted. |
+| `limit` | global default | 1–100 | Videos to keep for this channel. |
+| `enabled` | `true` | bool | Pause monitoring without deleting. |
+| `quality_preset` | global default | preset list above | Download quality for this channel. |
+| `schedule_override` | none | 5-field cron | Run this channel on its own schedule instead of the global one. Blank = use global. |
+
+### `config.yaml` example
+```yaml
+channels:
+  - url: "https://www.youtube.com/@MrsRachel"
+    limit: 20
+    enabled: true
+    quality_preset: "1080p"
+    schedule_override: "0 6 * * *"   # 6am daily; omit to use the global schedule
+
+settings:
+  default_video_limit: 10
+  default_quality_preset: "best"
+  cron_schedule: "0 */6 * * *"
+  scheduler_enabled: true
+  nfo_enabled: true
+  nfo_overwrite_existing: false
+  notification_url: "ntfy://ntfy.sh/my-topic"
+```
+
+---
+
+## Quality presets
+
+`quality_preset` maps to a yt-dlp format string:
+
+| Preset | Behavior |
+|--------|----------|
+| `best` | Best available video + audio. |
+| `2160p` / `1080p` / `720p` / `480p` | Best at or below that height, **falling back** to best-available if nothing qualifies. |
+
+Unknown values fall back to `best`. Changes take effect on the next download.
+
+---
+
+## Scheduling
+
+- **Global**: `cron_schedule` runs all channels that have **no** override.
+- **Per-channel**: a `schedule_override` moves that channel onto its own job.
+- Cron is standard 5-field (`minute hour day month weekday`); the minimum
+  interval is 5 minutes. The UI validates expressions live and previews the next
+  runs (backed by `GET /api/v1/scheduler/validate`).
+- Runs never overlap — a shared lock serializes the global job, per-channel jobs,
+  manual triggers, and reindex.
+
+---
+
+## Notifications
+
+Failure notifications use [Apprise](https://github.com/caronc/apprise): one URL
+fans out to many services. Set it under **Settings → Failure Notifications** or
+via `notification_url`. Examples:
+
+| Service | Example URL |
+|---------|-------------|
+| ntfy | `ntfy://ntfy.sh/my-topic` |
+| Discord | `discord://webhook_id/webhook_token` |
+| Telegram | `tgram://bot_token/chat_id` |
+| Email | `mailto://user:pass@gmail.com` |
+
+The URL is validated before saving, and a **Test** button sends a sample. A
+notification is sent (best-effort) when a scheduled or per-channel run has
+failures; it never affects downloading. See the full list at the Apprise wiki.
+
+---
+
+## YouTube cookies
+
+Some videos (age-restricted, or when YouTube demands sign-in) require cookies.
+Place a Netscape-format cookie file at `data/cookies.txt`. **Settings** shows
+whether it's present and its age (flagged **stale at 30 days** — YouTube session
+cookies expire within weeks, and expired cookies are the most common cause of
+downloads suddenly failing).
+
+---
+
+## Environment variables
+
+Read by `backend/app/config.py` (Pydantic settings). Defaults target the
+in-container paths used by the published image; you normally only set `TZ`.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `TZ` | `UTC` | Timezone for the scheduler (e.g. `America/Chicago`). |
+| `DATABASE_URL` | `sqlite:////app/data/app.db` | Main database. |
+| `MEDIA_DIR` | `/app/media` | Downloaded videos. |
+| `TEMP_DIR` | `/app/temp` | Download staging (use fast/SSD storage). |
+| `CONFIG_FILE` | `/app/data/config.yaml` | YAML config path. |
+| `COOKIES_FILE` | `/app/data/cookies.txt` | YouTube cookie file. |
+| `SCHEDULER_DATABASE_URL` | `sqlite:////app/data/scheduler_jobs.db` | APScheduler job store. |
+| `API_HOST` / `API_PORT` | `0.0.0.0` / `8000` | Backend bind address. |
+| `DEBUG` | `true` | Verbose logging / yt-dlp verbosity. |
+
+Container volumes (`data/`, `media/`, `temp/`) map these paths to the host — see
+the [Deployment Guide](DEPLOYMENT.md).
+
+---
+
+## Where each setting is stored
+
+| Kind | Store | Example |
+|------|-------|---------|
+| Container paths, timezone | Environment variables | `TZ`, `MEDIA_DIR` |
+| Global app settings | DB `application_settings` (mirrored to `config.yaml`) | `cron_schedule`, `notification_url` |
+| Per-channel settings | DB `channels` (mirrored to `config.yaml`) | `limit`, `quality_preset` |
+| Runtime locks/flags | DB `application_settings` | `scheduled_downloads_running` |
+| Scheduler jobs | `data/scheduler_jobs.db` | per-channel cron jobs |

--- a/docs/stories/story-005-channel-video-downloads.md
+++ b/docs/stories/story-005-channel-video-downloads.md
@@ -1,5 +1,12 @@
 # User Story: Channel Video Downloads
 
+> **As-built note:** This is the original planning spec. The shipped
+> implementation prevents duplicates using the **database + files on disk**
+> (`should_download_video`), **not** an `archive.txt` / `--download-archive`.
+> Automatic retry and cleanup were also added later. For current behavior see
+> the [User Guide](../user-guide.md#how-downloading-works) and
+> [TDD §6](../tdd.md#6-detailed-design).
+
 ## Section 1: Story Definition
 
 ### Feature

--- a/docs/stories/story-010-channel-status-dashboard.md
+++ b/docs/stories/story-010-channel-status-dashboard.md
@@ -1,5 +1,9 @@
 # US-007: Channel Status Dashboard
 
+> **As-built note:** Delivered. Live status updates use **polling** (and an SSE
+> stream for downloads), not WebSockets — the WebSocket items below remain
+> future roadmap. See the [User Guide](../user-guide.md#dashboard).
+
 ## Story Description
 
 As a user, I want to view all monitored channels with their current status so that I can see which channels are active and their basic information at a glance.

--- a/docs/stories/story-011-active-download-progress.md
+++ b/docs/stories/story-011-active-download-progress.md
@@ -1,5 +1,11 @@
 # US-008: Active Download Progress
 
+> **As-built note:** Delivered via yt-dlp progress hooks → an in-memory store →
+> **1–2s polling** in the UI, plus a **Server-Sent Events** stream
+> (`GET /api/v1/downloads/progress/stream`) for API consumers. The WebSocket
+> items below remain future roadmap. See the
+> [User Guide](../user-guide.md#live-progress).
+
 ## Story Description
 
 As a user, I want to see real-time progress of currently downloading videos so that I know the system is working and can estimate completion time.

--- a/docs/tdd.md
+++ b/docs/tdd.md
@@ -1,8 +1,13 @@
-## Technical Design Document (TDD) Outline
+## Technical Design Document (TDD)
 
 ### 1. Title & Metadata
-- YouTube Recent Video Downloader
-- Date: 2025-07-27
+- ChannelFinWatcher — YouTube Recent Video Downloader
+- Original design: 2025-07-27
+- Reflects the **as-built** system (all PRD user stories US-001–US-016 implemented)
+
+> **Reading note:** This document describes what is actually built. Items that
+> were considered but not implemented are collected in
+> [§15 Future Roadmap](#15-future-roadmap) rather than mixed into the design.
 
 ### 2. Summary / Scope
 - Refer to PRD in file @prd.md
@@ -19,58 +24,86 @@
 ### 5. Architecture Overview
 
 #### Deployment Architecture
-- **Multi-service Docker Compose**: Separate containers for backend and frontend with shared volumes
-- **Backend Container**: FastAPI application with Python dependencies and yt-dlp
-- **Frontend Container**: NextJS application with Node.js runtime
-- **Shared Volumes**: SQLite database, media directory, and configuration files
-- **Network Configuration**: Internal Docker network with frontend proxying API requests
-- **Alternative Single Container**: Option for combined build with nginx serving static files
+- **Production (single container)**: The published image
+  (`ghcr.io/miguelarios/channelfinwatcher`) runs both the FastAPI backend
+  (port 8000) and the NextJS frontend (port 3000) in one container, managed by
+  **supervisor**. `ffmpeg` and Node.js 20 are baked in (Node is required by
+  yt-dlp's EJS JavaScript decoding). Built from the root `Dockerfile`.
+- **Development (multi-container)**: `docker-compose.dev.yml` runs the backend
+  and frontend as separate hot-reloading containers with bind mounts.
+- **Shared Volumes**: `data/` (SQLite DBs, `config.yaml`, `cookies.txt`),
+  `media/` (downloaded videos), `temp/` (download staging).
 
 #### Two-Tier FastAPI + NextJS Architecture
-- **Frontend Layer**: NextJS React application providing modern, responsive UI with real-time capabilities
-- **Backend Layer**: FastAPI REST API with WebSocket support for real-time updates
-- **Application Layer**: Core business logic with background task processing via APScheduler
-- **Data Layer**: SQLite database for runtime state and YAML configuration for settings
+- **Frontend Layer**: NextJS React application (pages router). The frontend also
+  hosts thin API proxy routes under `pages/api/v1/*` that forward to the backend.
+- **Backend Layer**: FastAPI REST API. Blocking work (yt-dlp, ffmpeg, filesystem
+  scans) runs off the event loop via `asyncio.to_thread` / sync route handlers.
+- **Application Layer**: Core business logic with background task processing via
+  APScheduler (SQLite-persisted jobs, survives restarts).
+- **Data Layer**: SQLite database (Alembic-managed schema) plus a YAML mirror
+  of settings.
 
 #### Component Integration Model
-- NextJS frontend communicates with FastAPI backend via REST API and WebSockets
-- FastAPI handles all business logic, file operations, and background processing
-- Real-time updates flow through WebSocket connections for live progress tracking
-- Background scheduler runs independently of web requests
-- Clear separation of concerns between presentation and business logic
+- The NextJS frontend calls the FastAPI backend over REST (via its proxy routes).
+- Live download progress is surfaced by yt-dlp progress hooks writing to an
+  in-memory store, which the UI reads by polling `/downloads/active` (~every 1–2s)
+  and which is also exposed as a Server-Sent Events stream at
+  `/downloads/progress/stream` for direct API consumers.
+- The background scheduler runs independently of web requests.
 
 #### Configuration-Database Hybrid Model
-- **YAML Configuration**: Source of truth for channel definitions and system settings
-- **SQLite Database**: Runtime state storage and operational data
-- **File System**: Media storage maintaining existing organizational structure
+- **SQLite Database**: **Source of truth** for channels and settings, plus all
+  runtime/operational state.
+- **YAML Configuration** (`data/config.yaml`): A mirror of channels and settings,
+  written from the database for backup/transparency and readable back as a
+  fallback (e.g. if an advanced user edits it directly).
+- **File System**: Media storage maintaining the Jellyfin-compatible layout.
 
 ### 6. Detailed Design
 
 #### Data Models / Schema
-**SQLite Database Schema:**
-- **channels**: Channel definitions synchronized from YAML configuration
-- **downloads**: Complete download history and status tracking
-- **schedule_history**: Automated run tracking and performance metrics
-- **system_state**: Runtime locks and operational status
+**SQLite Database Schema** (see `backend/app/models.py`):
+- **channels**: Channel definitions and settings — `url`, `channel_id`, `name`,
+  `limit`, `enabled`, `quality_preset`, `schedule_override`, metadata/NFO
+  tracking fields, and timestamps.
+- **downloads**: Per-video download records — `video_id`, `title`, `status`
+  (pending/downloading/completed/failed), `file_path`, `file_size`,
+  `file_exists`, `deleted_at` (soft-delete for cleanup), `retry_count`, and
+  timestamps.
+- **download_history**: One row per download run (global or per-channel) —
+  `videos_found`, `videos_downloaded`, `videos_skipped`, `videos_failed`,
+  `status`, `run_date`, `completed_at`, `error_message`.
+- **application_settings**: Key/value store for all global settings and runtime
+  flags (e.g. `default_video_limit`, `default_quality_preset`, `cron_schedule`,
+  `scheduler_enabled`, `nfo_enabled`, `notification_url`, and the
+  `*_running` overlap-prevention locks).
+- APScheduler jobs persist in a separate `data/scheduler_jobs.db`.
 
-**YAML Configuration Structure:**
+> Schema changes are applied by **Alembic migrations** on startup, not by
+> `create_all`.
+
+**YAML Configuration Structure** (`data/config.yaml`, mirror of the DB):
 ```yaml
 channels:
-  - url: "https://www.youtube.com/c/ChannelName"
+  - url: "https://www.youtube.com/@ChannelName"
     limit: 10
     enabled: true
-    schedule_override: "0 */6 * * *"
-    quality_preset: "best"
+    quality_preset: "best"          # best | 2160p | 1080p | 720p | 480p
+    schedule_override: "0 6 * * *"  # optional per-channel cron
 
 settings:
-  schedule: "0 * * * *"  # Default cron expression
-  media_dir: "/media"
-  temp_dir: "/temp"
-  cookie_file: "/app/cookies.txt"
-  notifications:
-    enabled: false
-    webhook_url: ""
+  default_video_limit: 10
+  default_quality_preset: "best"
+  cron_schedule: "0 */6 * * *"      # global download schedule
+  scheduler_enabled: true
+  nfo_enabled: true
+  nfo_overwrite_existing: false
+  notification_url: ""              # Apprise URL; blank disables
 ```
+Paths (`media_dir`, `temp_dir`, `cookies_file`) are configured via environment
+variables, not YAML — see [§7 Tech Stack](#7-tech-stack) and the
+[Configuration Reference](configuration.md).
 
 #### File Organization
 **Directory Structure:**
@@ -85,50 +118,85 @@ settings:
 ```
 
 #### Core Algorithms
-- **Recent Video Detection**: Query channel feed, sort by upload date, apply configured limit
-- **Duplicate Prevention**: Check against download history using video IDs
-- **Configuration Synchronization**: Full sync between YAML file and database on startup
+- **Recent Video Detection**: A lightweight `extract_flat` yt-dlp query lists the
+  channel's most recent uploads; Shorts and live streams are filtered out at
+  extraction time. The configured `limit` bounds how many are kept.
+- **Duplicate Prevention**: `should_download_video()` decides per video using the
+  **database + disk state** (not an `archive.txt`): already-completed videos with
+  a file on disk are skipped; missing files are re-downloaded; orphaned files on
+  disk are re-indexed into the database.
+- **Quality Selection**: `quality_preset` maps to a yt-dlp format string
+  (`QUALITY_FORMATS`) with graceful fallback to best-available; unknown presets
+  fall back to `best`.
+- **Automatic Cleanup**: After a run, videos beyond the channel `limit` are
+  soft-deleted (files removed, DB row kept with `deleted_at` for history),
+  oldest / metadata-less first.
+- **Configuration Synchronization**: Database is authoritative; setting changes
+  are mirrored to `config.yaml`.
+
+#### Retry Policy
+- **Within a run**: transient failures (network/timeout/rate-limit, classified by
+  `utils.is_retryable_error`) retry up to `WITHIN_RUN_RETRIES` (2) extra times
+  with a short backoff.
+- **Across runs**: `retry_count` increments per failed run; after
+  `MAX_AUTO_RETRIES` (5) a video stops being auto-attempted. A manual retry
+  (`POST /downloads/{id}/retry`) resets the counter.
+- **Channel level**: the scheduled job retries a whole channel on transient
+  errors and isolates failures so one bad channel never stops the run.
+
+#### Overlap Prevention
+- A database-flag lock (`application_settings`, `{job}_running` keys) prevents
+  overlapping runs across the global job, per-channel jobs, manual triggers, and
+  reindex. Stale locks are cleared on startup. See `overlap_prevention.py`.
 
 #### Error Handling and Edge Cases
-- Channel-level errors: Skip and continue with next channel
-- Network failures: Retry with exponential backoff
-- Storage validation: Pre-check disk space before downloads
-- Invalid channels: Handle deleted/private channels gracefully
+- Channel-level errors: skip and continue with the next channel; a failed run is
+  still recorded in `download_history`.
+- Invalid channels: deleted/private channels are handled gracefully.
+- All blocking yt-dlp/ffmpeg/filesystem work runs off the async event loop.
 
-#### Real-Time Capabilities
-- **WebSocket Connections**: Live progress updates for active downloads (US-008)
-- **Server-Sent Events**: System status and storage monitoring updates (US-010)
-- **Background Task Status**: Real-time feedback on download progress and completion
-- **Live Configuration Updates**: Instant UI updates when YAML configuration changes
+#### Live Progress Capabilities
+- **Progress store**: yt-dlp `progress_hooks` write percent/speed/ETA for each
+  active video into an in-memory, thread-safe store (`progress_store.py`).
+  Entries are added on start and always removed on completion/failure.
+- **Polling**: the dashboard's *Active Downloads* panel polls `/downloads/active`.
+- **Server-Sent Events**: `/downloads/progress/stream` emits a JSON snapshot each
+  second for direct API consumers. (The bundled UI polls rather than consuming
+  SSE because the Next.js pages-router proxy buffers streaming responses.)
 
 #### State Management
-- **Frontend State**: React state management with React Query for API caching
-- **Backend State**: SQLite database for permanent storage and runtime locks
-- **Real-time State**: WebSocket connections maintain live data synchronization
-- **File System Access**: Direct media operations through FastAPI endpoints
-- **Configuration Management**: YAML configuration with hot-reloading capabilities
+- **Frontend State**: React component state; data fetched via the frontend's
+  `/api/v1/*` proxy routes. (React Query is a dependency but not broadly used —
+  see [§15 Future Roadmap](#15-future-roadmap).)
+- **Backend State**: SQLite for persistent data and runtime locks; the in-memory
+  progress store and log ring-buffer for ephemeral state.
+- **Time convention**: all timestamps are **naive UTC** end-to-end, produced via
+  `app/time_utils.py` (`utc_now()` / `utc_from_timestamp()`); the frontend
+  appends `Z` when parsing.
 
 ### 7. Tech Stack
 
 #### Backend Framework
-- **Python**: Primary backend application language
-- **FastAPI**: Modern, high-performance web framework for REST API and WebSocket endpoints
-- **SQLite**: Zero-configuration database for data persistence
-- **APScheduler**: Pure Python scheduling solution for automated downloads
-- **Uvicorn**: ASGI server for FastAPI application
+- **Python 3.11** with **FastAPI** (REST API) and **Uvicorn** (ASGI server)
+- **SQLite** via **SQLAlchemy**, schema managed by **Alembic** migrations
+- **APScheduler**: automated downloads; jobs persisted to SQLite so they survive
+  container restarts
+- **Pydantic v2**: request/response validation and serialization
 
 #### Frontend Framework
-- **NextJS**: React-based framework for modern, responsive user interface
-- **TypeScript**: Type-safe JavaScript for better development experience
-- **TailwindCSS**: Utility-first CSS framework for rapid UI development
-- **React Query**: Data fetching and caching for API interactions
+- **NextJS** (pages router) with **TypeScript** and **TailwindCSS**
+- **lucide-react** for icons
+- React Query is installed but currently only lightly used (see roadmap)
 
 #### Key Libraries
-- **yt-dlp**: YouTube downloading and metadata extraction
-- **PyYAML**: YAML configuration file parsing and validation
-- **apprise**: Notification system integration (planned)
-- **WebSockets**: Real-time communication between frontend and backend
-- **Pydantic**: Data validation and serialization for API models
+- **yt-dlp** (`[default]` extra, incl. EJS/Node.js JS decoding): downloading and
+  metadata extraction
+- **ffmpeg**: muxing to `.mkv`, thumbnail/subtitle/metadata embedding
+- **PyYAML**: YAML config read/write
+- **apprise**: failure-notification delivery (implemented; Discord, ntfy,
+  Telegram, email, and many more)
+- **Environment paths** are read from env vars via Pydantic settings
+  (`app/config.py`)
 
 ### 8. Third-Party Dependencies
 
@@ -166,31 +234,79 @@ settings:
 - **Configuration Privacy**: YAML files contain only public channel URLs
 
 ### 10. Testing Strategy
-- No testing for now. 
+- **Backend**: pytest suite (unit + integration) using an in-memory SQLite
+  database and FastAPI's `TestClient`; yt-dlp/network calls are mocked. Covers
+  the API, download pipeline, retry policy, scheduling, cleanup, progress store,
+  health checks, notifications, and the log buffer.
+- **Frontend**: Jest + React Testing Library component tests with mocked
+  `fetch`; TypeScript is type-checked (`tsc --noEmit`).
+- **CI**: builds both images and runs an automated review on every PR (see
+  `docs/CI-CD-EXPLAINED.md`).
+- Run locally: `cd backend && python -m pytest` and `cd frontend && npx jest`.
+  See [docs/testing-guide.md](testing-guide.md).
 
 ### 11. Monitoring & Observability
 
 #### Logging Strategy
-- **Application Logging**: Structured logging for operational events
-- **Download Progress**: Real-time progress tracking and completion status
-- **Error Logging**: Detailed error context for troubleshooting
-- **Docker Logs**: Centralized logging accessible through container logs
+- **Application Logging**: Python `logging`, INFO by default.
+- **Docker Logs**: Primary troubleshooting channel.
+- **In-app Log Buffer**: The last 500 records are kept in an in-memory
+  ring-buffer handler and served at `GET /api/v1/logs/recent` (filterable by
+  level) so logs are reachable without shell access.
 
-#### Notification System
-- **Apprise Integration**: External notification capabilities
-- **Event Types**: Download completion, errors, system status
-- **Configuration**: Optional webhook and notification service setup
+#### Notification System (implemented)
+- **Apprise Integration**: `notification_service.py`. A single Apprise URL
+  (`notification_url` setting) fans out to any supported service.
+- **Trigger**: best-effort notification when scheduled/per-channel runs have
+  failures. Dispatch runs off the event loop and never affects downloads.
+- **Configuration & Test**: `GET/PUT /settings/notifications` and
+  `POST /settings/notifications/test`, plus a Settings-page UI.
 
 #### System Monitoring
-- **Health Checks**: Basic application health endpoints
-- **Resource Tracking**: Storage usage and download performance
-- **Status Dashboard**: Real-time system status in web interface
+- **Deep Health Check**: `GET /health` verifies database connectivity, yt-dlp
+  importability/version, `ffmpeg`/`ffprobe` presence, media-volume capacity
+  (flagged at ≥90%), and scheduler liveness (enabled but silent >48h = stale).
+  Returns `healthy`/`degraded` with an explicit `problems` list, always HTTP 200
+  so container healthchecks measure reachability.
+- **Cookie Health**: `GET /settings/cookies-status` reports the YouTube cookie
+  file's presence and age (stale at 30 days) — expired cookies are the most
+  common silent breakage.
+- **Storage Monitoring**: The dashboard shows per-channel and total storage plus
+  a capacity gauge with an 80% warning banner.
+- **Status Dashboard**: Channel health cards, live download progress, and
+  scheduler status.
 
 ### 12. Migration Plan
-- Not applicable as this is a personal project
+- **Schema migrations**: Alembic migrations in `backend/alembic/versions/` run
+  automatically on startup (`command.upgrade(cfg, "head")`), so existing
+  databases upgrade in place. New columns ship with server defaults for safe
+  in-place upgrades.
 
 ### 13. Risks & Alternatives Considered
-- Not applicable, i think.
+- **YouTube breakage** is the main operational risk (extraction changes, bot
+  detection). Mitigations: cookie support with age warnings, yt-dlp `[default]`
+  EJS decoding, `/health` surfacing yt-dlp availability, and per-video retry.
+- **Single-process concurrency**: blocking work is offloaded with
+  `asyncio.to_thread`; SQLite uses a busy timeout and cross-thread sessions are
+  used sequentially (documented in `database.py`).
+
+### 15. Future Roadmap
+
+Considered but **not implemented** — tracked here so the design above stays
+strictly as-built:
+
+- **WebSocket transport** for live updates. Today the UI polls `/downloads/active`
+  and an SSE stream exists for API consumers; a WebSocket push channel was in the
+  original design but is not built.
+- **Authentication / multi-user**. The app is intentionally single-user for a
+  trusted LAN (a PRD non-goal). Note: `GET /settings/notifications` and
+  `GET /settings/cookies-status` return values that can look secret-shaped
+  (webhook URLs, file paths); revisit masking if remote access is ever added.
+- **React Query adoption** across the frontend to replace hand-rolled
+  fetch/loading/error state (the dependency is present but underused).
+- **Storage trends & projections** (daily/weekly growth, time-until-full),
+  charts, and per-channel storage export.
+- **Bandwidth / concurrent-download limits** and custom metadata templates.
 
 ### 14. References.
 

--- a/docs/tech-docs/download-user-guide.md
+++ b/docs/tech-docs/download-user-guide.md
@@ -12,7 +12,7 @@ This guide explains how the video download system works and how to troubleshoot 
 
 **Recent Videos Only**: Uses lightweight flat-playlist queries to get the most recent X videos (based on your channel limit setting) efficiently
 
-**Duplicate Prevention**: Uses `archive.txt` to remember what's already downloaded - won't re-download the same video
+**Duplicate Prevention**: Tracks what's already downloaded using the **database and files on disk** (not an `archive.txt`) — won't re-download a video that's already present. If a file goes missing it is re-downloaded, and files you add manually are picked up via **Reindex**.
 
 **Smart Skipping**: If a channel has 50 videos but your limit is 10, only downloads the 10 most recent ones
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,216 @@
+# User Guide
+
+Everything ChannelFinWatcher does, and how to use it. This covers the web
+interface and how downloads behave. For deployment see the
+[Deployment Guide](DEPLOYMENT.md); for settings details see the
+[Configuration Reference](configuration.md).
+
+## Contents
+- [Quick start](#quick-start)
+- [Dashboard](#dashboard)
+- [Channels](#channels)
+- [History](#history)
+- [Settings](#settings)
+- [How downloading works](#how-downloading-works)
+- [Live progress](#live-progress)
+- [Cookies](#youtube-cookies)
+- [Notifications](#failure-notifications)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Quick start
+
+1. Open the web UI (default `http://<host>:3333`).
+2. Go to **Channels** and paste a YouTube channel URL (`@handle`,
+   `/channel/UC…`, `/c/…`, or `/user/…` all work).
+3. Optionally set a video limit and quality — or leave them to use the global
+   defaults.
+4. Click **Add Channel**. Metadata is fetched and the most recent videos begin
+   downloading immediately.
+5. Watch progress on the **Dashboard**.
+
+By default a scheduled run every 6 hours keeps each channel's newest videos, and
+older videos beyond each channel's limit are cleaned up automatically.
+
+---
+
+## Dashboard
+
+The landing page — a live overview of the whole system.
+
+- **Scheduler status** — whether automatic downloads are enabled, the schedule,
+  and the next run.
+- **Active Downloads** — live progress bars for anything downloading right now
+  (title, channel, percent, size, speed, ETA). Hidden when nothing is running.
+  See [Live progress](#live-progress).
+- **Storage** — a capacity gauge for your media volume with an **80% warning
+  banner**, plus how much space your videos use.
+- **Library totals** — channel count, enabled count, total videos, total video
+  storage.
+- **Channel cards** — one per channel with a health dot:
+  - 🟢 **Active** · 🔴 **Last run failed** · 🟡 **Never checked** · ⚪ **Disabled**
+  - Shows videos vs limit (e.g. `8/10`), storage used, last-check time, a custom
+    schedule indicator, and the last error if the most recent run failed.
+- **Search / sort** the cards, quickly **enable/disable** a channel, and refresh.
+  Auto-refreshes every 30 seconds.
+
+---
+
+## Channels
+
+Add channels and manage each one. Per-channel actions live in the **⋮ (kebab)
+menu** on each row:
+
+| Action | What it does |
+|--------|--------------|
+| **Edit limit** | Click the limit to change how many videos are kept (1–100). Large reductions ask for confirmation before deleting. |
+| **Quality** | Set this channel's download quality (`best`/`2160p`/`1080p`/`720p`/`480p`). Takes effect next download. |
+| **Custom schedule** | Give this channel its own cron schedule instead of the global one — with live validation and a next-run preview. Clear it to return to the global schedule. |
+| **Download recent videos** | Trigger a download run now. If a scheduled run is in progress, it's queued. |
+| **Refresh metadata** | Re-fetch the channel's name, artwork, and info. |
+| **Reindex media** | Reconcile the database with what's actually on disk (useful after manual file changes). |
+| **Regenerate NFO files** | Rebuild Jellyfin `.nfo` metadata for the channel. |
+| **Enable / disable** | Pause monitoring without deleting. Disabled channels are skipped by scheduled runs. |
+| **Delete** | Remove the channel. You choose whether to also delete its media files. |
+
+---
+
+## History
+
+A cross-channel record of every video download.
+
+- **Filter** by channel and by status (completed, failed, downloading, pending).
+- **Paginated**, newest first; each row shows the video (with a YouTube link),
+  channel, status, size, and date.
+- **Failed** rows show the error and a **Retry** button. Retrying resets that
+  video's retry budget and re-attempts immediately.
+- Videos removed by automatic cleanup show a **Cleaned up** badge (the history
+  row is kept even after the file is deleted).
+
+---
+
+## Settings
+
+Global configuration. See the [Configuration Reference](configuration.md) for
+every value and its default.
+
+- **Default Video Limit** — applied to new channels (1–100).
+- **Default Video Quality** — applied to new channels.
+- **Automatic Download Scheduler** — the global cron schedule (with live
+  validation and next-run preview) and a master enable/disable switch.
+- **NFO Generation** — toggle Jellyfin `.nfo` generation and whether
+  regeneration overwrites existing files. A **backfill** tool generates NFO for
+  channels added before NFO was enabled.
+- **System Health & Alerts**:
+  - **YouTube Cookies** — presence and age of your cookie file, with a warning
+    when it's stale. See [Cookies](#youtube-cookies).
+  - **Failure Notifications** — an Apprise URL plus a **Test** button. See
+    [Notifications](#failure-notifications).
+
+Changing a default affects **new** channels only; existing channels keep their
+own settings.
+
+---
+
+## How downloading works
+
+- **Recent videos only** — a fast, lightweight query lists a channel's newest
+  uploads. **Shorts and live streams are filtered out.** Only the configured
+  number of most-recent regular videos are kept.
+- **No duplicates** — the app tracks what it has by database + files on disk.
+  Already-downloaded videos are skipped; missing files are re-downloaded; files
+  you added manually are picked up by **Reindex**.
+- **Sequential** — videos and channels download one at a time to be gentle on
+  your system and YouTube.
+- **Automatic cleanup** — after a run, videos beyond a channel's limit are
+  removed (oldest first). The history row is kept and marked *Cleaned up*.
+- **Automatic retry**:
+  - *Within a run*, transient failures (network/timeout/rate-limit) retry a
+    couple of times with a short backoff.
+  - *Across runs*, a video that keeps failing stops being retried automatically
+    after 5 failed runs — use **Retry** in History to try again (which resets
+    the counter).
+- **Jellyfin layout** — files are organized as
+  `Channel [id]/YYYY/Channel - date - title [id]/…` with the video (`.mkv`),
+  `.info.json`, thumbnail, subtitles, and `.nfo` alongside.
+- **Scheduling** — runs happen on the global schedule, except channels with a
+  custom schedule which run on their own. You can always trigger a run manually.
+
+---
+
+## Live progress
+
+While videos download, the **Active Downloads** panel on the dashboard shows a
+progress bar per video with percent, transfer size, speed, and ETA. After the
+transfer finishes, a video briefly shows **Processing** while yt-dlp muxes and
+embeds metadata, then it disappears from the panel and appears in **History**.
+
+The panel updates by polling every couple of seconds. Direct API consumers can
+instead subscribe to a Server-Sent Events stream at
+`GET /api/v1/downloads/progress/stream` (see the [API Reference](api-reference.md)).
+
+---
+
+## YouTube cookies
+
+Some videos need you to be signed in (age-restricted content, or when YouTube
+challenges the downloader). To enable those:
+
+1. Export your YouTube cookies in **Netscape format** (e.g. a "Get cookies.txt"
+   browser extension while logged into YouTube).
+2. Save the file as `data/cookies.txt` next to your `docker-compose.yml`.
+3. Restart the container.
+
+**Settings → YouTube Cookies** shows whether the file is present and how old it
+is. YouTube session cookies expire within weeks; the UI flags the file as
+**stale at 30 days**. Expired cookies are the single most common reason
+downloads suddenly start failing — re-export when you see the warning.
+
+---
+
+## Failure notifications
+
+Get alerted when scheduled downloads fail. ChannelFinWatcher uses
+[Apprise](https://github.com/caronc/apprise), so one URL can target Discord,
+ntfy, Telegram, email, and dozens more.
+
+1. **Settings → Failure Notifications**, paste an Apprise URL
+   (e.g. `ntfy://ntfy.sh/my-topic`), and **Save**. The URL is validated first.
+2. Click **Test** to send a sample.
+
+A notification is sent (best-effort) when a scheduled or per-channel run has
+failures. It never interferes with downloading. Leave the field blank to
+disable. Example URLs are in the [Configuration Reference](configuration.md).
+
+---
+
+## Troubleshooting
+
+**Downloads suddenly failing / "Sign in to confirm"** — your cookies are likely
+expired. Check **Settings → YouTube Cookies** and re-export (see above).
+
+**A specific video won't download** — open **History**, filter by **Failed**,
+read the error, and click **Retry**. After 5 failed runs a video stops
+auto-retrying until you retry it manually.
+
+**Is the system healthy?** — `curl http://<host>:8000/health` reports database,
+yt-dlp, ffmpeg, disk, and scheduler status (`healthy`/`degraded` with a
+`problems` list).
+
+**Where are the logs?** — `docker compose logs -f`, or the last 500 records via
+`GET /api/v1/logs/recent`.
+
+**Storage filling up** — the dashboard warns at 80%. Lower per-channel limits;
+cleanup removes the excess on the next run.
+
+**Scheduled runs not happening** — confirm the scheduler is **enabled** in
+Settings, check the channel isn't disabled, and verify `TZ` is set correctly
+(the schedule uses your timezone).
+
+**Database is locked / concurrency** — rare; the app serializes runs and uses a
+lock timeout. If a manual action returns **409**, a scheduled run is in
+progress — try again when it finishes.
+
+More: the [FAQ-style deployment troubleshooting](DEPLOYMENT.md#troubleshooting)
+and [GitHub Issues](https://github.com/miguelarios/ChannelFinWatcher/issues).


### PR DESCRIPTION
## Summary

Brings all feature documentation up to date with the as-built system. Documentation-only — no code changes. Anything considered but not implemented (WebSocket transport, auth/multi-user, storage-trend charts, broad React Query adoption) is kept as clearly-labeled **future roadmap** rather than presented as built.

### New documents (the biggest gaps)
- **`docs/user-guide.md`** — every feature and view (dashboard, channels, history, settings), how downloading/retry/cleanup work, cookies, notifications, and troubleshooting.
- **`docs/configuration.md`** — every setting and where it lives (web UI vs `config.yaml` vs env vars): quality presets, scheduling, notifications, cookies.
- **`docs/api-reference.md`** — all REST endpoints, taken from the actual route decorators in `backend/app/api.py`/`main.py`, grouped by area.
- **`docs/README.md`** — documentation index with a feature→doc map.

### Corrected stale docs
- **README.md** — removed the obsolete production-deploy steps (compose already uses `./data`; the `./test/data → ./data` change was fixed back in #39), corrected the architecture to the single supervisor container, replaced the WebSocket claim with polling + SSE, and added a config example, doc links, and a roadmap section.
- **docs/tdd.md** — fixed wrong table names (`schedule_history`/`system_state` → `download_history`/`application_settings`), WebSockets-as-built → hooks + polling + SSE, "No testing for now" → the real pytest/Jest strategy, apprise "planned" → implemented, plus retry/cleanup/overlap-prevention, deep health checks, the naive-UTC time convention, Alembic migrations, and a Future Roadmap section.
- **docs/DEPLOYMENT.md** — `.mp4` → `.mkv` output layout, documented the deep `/health` and `/logs/recent` endpoints, cross-linked the configuration reference.
- **download-user-guide.md** — dedup is DB + disk, not `archive.txt`.
- **stories 005/010/011** — added "as-built" notes where the shipped approach diverged from the original spec (DB dedup; polling/SSE, not WebSocket).

### Verification
- All internal doc links resolve to existing files/anchors (checked).
- API reference cross-checked against the route decorators in source.
- No code touched, so no test impact.

https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BusPUhUbAPmRbpmtn5n2sd)_