### PR TITLE
Translate yt-dlp errors into user-friendly download failure messages

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -713,8 +713,14 @@ def friendly_download_error(raw_messages: Optional[List[str]]) -> Optional[str]:
          "This video is geo-blocked in your region and can't be downloaded from here."),
         ([("requested format is not available",), ("requested format not available",)],
          "The selected quality/format isn't available for this video. Try a different quality preset."),
-        # Stale yt-dlp vs. YouTube player changes — the fix is to update yt-dlp
-        ([("nsig",), ("unable to extract",), ("signature", "extract"), ("player", "extract")],
+        # Stale yt-dlp vs. YouTube player changes — the fix is to update yt-dlp.
+        # Deliberately require player/signature/nsig context: a bare
+        # "unable to extract" is too broad (yt-dlp uses it for metadata,
+        # uploader id, thumbnails, …) and would wrongly claim an unrelated
+        # extraction failure is a stale-player problem — and, being
+        # higher-priority than the network rule, could strip a retry keyword
+        # from a line that also carried one.
+        ([("nsig",), ("signature", "extract"), ("player", "extract")],
          "YouTube changed its player and the installed yt-dlp can't decode this "
          "video. Update yt-dlp (rebuild the container) and try again."),
         # Transient conditions (must keep an is_retryable_error keyword)

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -5,7 +5,7 @@ import yaml
 import threading
 import re
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from app.config import get_settings
 from app.time_utils import utc_now
 
@@ -574,6 +574,129 @@ def is_retryable_error(error_message: str) -> bool:
 
     error_lower = error_message.lower()
     return any(keyword in error_lower for keyword in retryable_keywords)
+
+
+class YtdlpErrorCapture:
+    """Capture yt-dlp's own error/warning output for later inspection.
+
+    Why this exists: our download options set ``ignoreerrors=True`` so a single
+    bad video never aborts a whole channel run. The trade-off is that yt-dlp
+    swallows the exception internally — ``ydl.download()`` returns normally even
+    when nothing was downloaded, and the *real* reason (bot check, private
+    video, format gone, stale player code, …) is lost. The caller is left only
+    with "the file isn't on disk", which is useless for troubleshooting.
+
+    yt-dlp accepts any object exposing ``debug``/``info``/``warning``/``error``
+    as its ``logger`` option and routes all of its messages through it. By
+    plugging this in we keep a copy of the error/warning lines (the ones that
+    explain *why* a download produced no file) so we can translate them into a
+    friendly message, while still forwarding everything to the app logger at
+    DEBUG level so nothing is silently dropped.
+    """
+
+    def __init__(self, app_logger: Optional[logging.Logger] = None):
+        # Forward to the module logger by default; callers may pass their own
+        self._app_logger = app_logger or logger
+        self.errors: List[str] = []
+        self.warnings: List[str] = []
+
+    def debug(self, msg: str) -> None:
+        # yt-dlp funnels both debug and info lines through debug(); keep them
+        # at DEBUG so INFO-mode logs stay quiet but nothing is lost in DEBUG.
+        self._app_logger.debug("[yt-dlp] %s", msg)
+
+    def info(self, msg: str) -> None:
+        self._app_logger.debug("[yt-dlp] %s", msg)
+
+    def warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+        self._app_logger.debug("[yt-dlp][warning] %s", msg)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+        self._app_logger.debug("[yt-dlp][error] %s", msg)
+
+    @property
+    def messages(self) -> List[str]:
+        """All captured lines, errors first (most explanatory), then warnings."""
+        return self.errors + self.warnings
+
+
+def friendly_download_error(raw_messages: List[str]) -> Optional[str]:
+    """Translate raw yt-dlp error/warning text into a short, human-friendly reason.
+
+    Turns yt-dlp's technical output into something a non-technical user can act
+    on ("refresh your cookies", "the video is private", "update the app"). This
+    is intentionally keyword-based rather than regex-heavy: yt-dlp's wording
+    shifts between releases, so we match on stable substrings and keep the rules
+    ordered from most specific/most common to least.
+
+    Args:
+        raw_messages: Captured yt-dlp error/warning lines (see YtdlpErrorCapture)
+
+    Returns:
+        A friendly one-line explanation, or None if nothing usable was captured
+        (the caller should then fall back to its own generic message).
+    """
+    non_empty = [m for m in (raw_messages or []) if m and m.strip()]
+    if not non_empty:
+        return None
+
+    blob = " ".join(non_empty).lower()
+
+    # Age restriction is checked before the generic bot message because both
+    # begin with "Sign in to confirm ..." ("...your age" vs "...you're not a bot").
+    if "age" in blob and ("restrict" in blob or "confirm your age" in blob or "inappropriate" in blob):
+        return "This video is age-restricted. Cookies from a signed-in, age-verified account are required."
+
+    # Bot detection / missing-expired cookies — by far the most common cause of
+    # "downloads stopped working" after a period of running fine.
+    if ("sign in to confirm" in blob or "not a bot" in blob
+            or ("confirm you" in blob and "bot" in blob)):
+        return ("YouTube blocked the download with a bot check. Your cookies are "
+                "likely missing or expired — export a fresh cookies file from a "
+                "signed-in browser session.")
+
+    # Video no longer downloadable for account/visibility reasons
+    if "private video" in blob:
+        return "This video is private and can no longer be downloaded."
+    if ("video unavailable" in blob or "no longer available" in blob
+            or "removed by the uploader" in blob or "account associated" in blob
+            or "has been terminated" in blob):
+        return "This video is unavailable (deleted, removed, or the channel was terminated)."
+    if "members-only" in blob or "members only" in blob or "join this channel" in blob:
+        return "This video is members-only and needs a channel membership (and matching cookies) to download."
+
+    # Region / format issues
+    if ("available in your country" in blob or "blocked it in your country" in blob
+            or ("geo" in blob and "restrict" in blob)):
+        return "This video is geo-blocked in your region and can't be downloaded from here."
+    if "requested format is not available" in blob or "requested format not available" in blob:
+        return "The selected quality/format isn't available for this video. Try a different quality preset."
+
+    # Stale yt-dlp vs. YouTube player changes — the fix is to update yt-dlp
+    if ("nsig" in blob or "unable to extract" in blob
+            or ("signature" in blob and "extract" in blob)
+            or ("player" in blob and "extract" in blob)):
+        return ("YouTube changed its player and the installed yt-dlp can't decode this "
+                "video. Update yt-dlp (rebuild the container) and try again.")
+
+    # Transient conditions
+    if "http error 429" in blob or "too many requests" in blob:
+        return "YouTube is rate-limiting downloads (HTTP 429). Wait a while before retrying."
+    if ("timed out" in blob or "timeout" in blob or "connection" in blob
+            or "network" in blob or "getaddrinfo" in blob
+            or "temporary failure in name resolution" in blob):
+        return "A network error interrupted the download. This is usually temporary — retry later."
+
+    # We captured something we don't have a canned message for. Surfacing the
+    # real (trimmed) yt-dlp line still beats an opaque "file not found".
+    last = non_empty[-1].strip()
+    # Drop yt-dlp's noisy "ERROR: " prefix for readability
+    for prefix in ("ERROR: ", "WARNING: "):
+        if last.startswith(prefix):
+            last = last[len(prefix):]
+    return f"Download failed: {last}" if last else None
 
 
 def get_default_quality_preset(db_session=None) -> str:

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -653,6 +653,18 @@ def friendly_download_error(raw_messages: Optional[List[str]]) -> Optional[str]:
     Returns:
         A friendly one-line explanation, or None if nothing usable was captured
         (the caller should then fall back to its own generic message).
+
+    Invariants worth preserving if you add branches:
+    - Matching runs over the *combined* text of the given lines. Callers pass
+      the fatal error line(s) (see YtdlpErrorCapture.messages), which are
+      effectively single-cause per video, so branch priority order decides the
+      result. If multiple conflicting error lines are ever passed, the
+      highest-priority branch wins.
+    - This output is fed to is_retryable_error() by the retry layer. Retryable
+      causes (rate-limit/network) MUST keep a keyword it recognizes ("429",
+      "network", …) in their friendly text; non-retryable causes must not. The
+      last-resort branch preserves the raw line, so unclassified transient
+      errors stay retryable by keyword survival.
     """
     non_empty = [m for m in (raw_messages or []) if m and m.strip()]
     if not non_empty:

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -668,11 +668,21 @@ def friendly_download_error(raw_messages: Optional[List[str]]) -> Optional[str]:
       last-resort branch preserves the raw line, so unclassified transient
       errors stay retryable by keyword survival.
     """
-    non_empty = [m for m in (raw_messages or []) if m and m.strip()]
-    if not non_empty:
+    # Expand every captured message into individual physical lines. A single
+    # message can itself embed newlines (a yt-dlp DownloadError string often
+    # chains several causes), and matching a multi-line string as one unit would
+    # let a two-keyword rule bleed across its lines — the same failure mode the
+    # per-line matching guards against for separate list entries. Splitting here
+    # gives every call site (capture path and DownloadError path alike) the same
+    # per-line guarantee.
+    source_lines = [
+        ln for m in (raw_messages or []) if m
+        for ln in m.splitlines() if ln.strip()
+    ]
+    if not source_lines:
         return None
 
-    lines = [m.lower() for m in non_empty]
+    lines = [ln.lower() for ln in source_lines]
 
     # Each rule: (clauses, friendly_message). A line matches the rule if it
     # satisfies ANY clause; a clause is a tuple of substrings that must ALL be
@@ -723,8 +733,10 @@ def friendly_download_error(raw_messages: Optional[List[str]]) -> Optional[str]:
             return message
 
     # We captured something we don't have a canned message for. Surfacing the
-    # real (trimmed) yt-dlp line still beats an opaque "file not found".
-    last = non_empty[-1].strip()
+    # real (trimmed) yt-dlp line still beats an opaque "file not found". Use the
+    # LAST line: yt-dlp's terminal line is usually the actual cause, with any
+    # preceding lines being context/traceback leading up to it.
+    last = source_lines[-1].strip()
     # Drop one leading "ERROR: "/"WARNING: " prefix for readability
     for prefix in ("ERROR: ", "WARNING: "):
         if last.startswith(prefix):

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -618,14 +618,24 @@ class YtdlpErrorCapture:
 
     @property
     def messages(self) -> List[str]:
-        """All captured lines, warnings first and errors last.
+        """Captured lines most relevant to diagnosing the failure.
 
-        The error lines are the ones that explain *why* a download failed, so
-        they go last: friendly_download_error's fallback surfaces the final
-        line, and we want that to be the real error, not an incidental warning
-        (e.g. "unable to download thumbnail") that happened to be logged too.
+        yt-dlp is noisy: a failed run often logs several *benign* warnings
+        (thumbnail/subtitle failures, format fallbacks, "some formats are
+        missing") alongside the one fatal ERROR. Under ``ignoreerrors=True`` the
+        fatal cause is reported through ``error()``, so we classify on the error
+        lines when any exist and only fall back to warnings when none were
+        captured.
+
+        Why this matters beyond the message text: the translated message is
+        also fed to ``is_retryable_error`` (see
+        ``download_video_with_retry``). If an incidental warning outranked the
+        real cause, a genuinely transient failure could be mislabeled
+        non-retryable and silently skip its within-run retry. Preferring the
+        error lines keeps both the user-facing message and the retry decision
+        anchored to what actually failed.
         """
-        return self.warnings + self.errors
+        return self.errors or self.warnings
 
 
 def friendly_download_error(raw_messages: Optional[List[str]]) -> Optional[str]:
@@ -701,10 +711,11 @@ def friendly_download_error(raw_messages: Optional[List[str]]) -> Optional[str]:
     # We captured something we don't have a canned message for. Surfacing the
     # real (trimmed) yt-dlp line still beats an opaque "file not found".
     last = non_empty[-1].strip()
-    # Drop yt-dlp's noisy "ERROR: " prefix for readability
+    # Drop one leading "ERROR: "/"WARNING: " prefix for readability
     for prefix in ("ERROR: ", "WARNING: "):
         if last.startswith(prefix):
             last = last[len(prefix):]
+            break
     return f"Download failed: {last}" if last else None
 
 

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -618,11 +618,17 @@ class YtdlpErrorCapture:
 
     @property
     def messages(self) -> List[str]:
-        """All captured lines, errors first (most explanatory), then warnings."""
-        return self.errors + self.warnings
+        """All captured lines, warnings first and errors last.
+
+        The error lines are the ones that explain *why* a download failed, so
+        they go last: friendly_download_error's fallback surfaces the final
+        line, and we want that to be the real error, not an incidental warning
+        (e.g. "unable to download thumbnail") that happened to be logged too.
+        """
+        return self.warnings + self.errors
 
 
-def friendly_download_error(raw_messages: List[str]) -> Optional[str]:
+def friendly_download_error(raw_messages: Optional[List[str]]) -> Optional[str]:
     """Translate raw yt-dlp error/warning text into a short, human-friendly reason.
 
     Turns yt-dlp's technical output into something a non-technical user can act
@@ -646,7 +652,10 @@ def friendly_download_error(raw_messages: List[str]) -> Optional[str]:
 
     # Age restriction is checked before the generic bot message because both
     # begin with "Sign in to confirm ..." ("...your age" vs "...you're not a bot").
-    if "age" in blob and ("restrict" in blob or "confirm your age" in blob or "inappropriate" in blob):
+    # Match specific phrases rather than a bare "age" substring, which would
+    # also fire on unrelated words ("storage", "message", "usage", …).
+    if ("confirm your age" in blob or "age-restricted" in blob
+            or "age restricted" in blob or "inappropriate for some users" in blob):
         return "This video is age-restricted. Cookies from a signed-in, age-verified account are required."
 
     # Bot detection / missing-expired cookies — by far the most common cause of

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -591,7 +591,9 @@ class YtdlpErrorCapture:
     plugging this in we keep a copy of the error/warning lines (the ones that
     explain *why* a download produced no file) so we can translate them into a
     friendly message, while still forwarding everything to the app logger at
-    DEBUG level so nothing is silently dropped.
+    DEBUG level. Note the forwarded copy is only *visible* when the deployment
+    persists DEBUG logs; the captured copy used for translation does not depend
+    on the log level.
     """
 
     def __init__(self, app_logger: Optional[logging.Logger] = None):

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -654,12 +654,14 @@ def friendly_download_error(raw_messages: Optional[List[str]]) -> Optional[str]:
         A friendly one-line explanation, or None if nothing usable was captured
         (the caller should then fall back to its own generic message).
 
-    Invariants worth preserving if you add branches:
-    - Matching runs over the *combined* text of the given lines. Callers pass
-      the fatal error line(s) (see YtdlpErrorCapture.messages), which are
-      effectively single-cause per video, so branch priority order decides the
-      result. If multiple conflicting error lines are ever passed, the
-      highest-priority branch wins.
+    Invariants worth preserving if you add rules:
+    - Each rule is matched against a *single* line, and rules are tried in
+      priority order, so the highest-priority category any one line describes
+      wins. Matching per-line (rather than over one joined blob) prevents a
+      multi-keyword rule from being satisfied by keywords bleeding across two
+      unrelated lines (e.g. "geo" in one line + "restrict" in another).
+    - Age restriction is ordered before the generic bot rule because both begin
+      with "Sign in to confirm ..." ("...your age" vs "...you're not a bot").
     - This output is fed to is_retryable_error() by the retry layer. Retryable
       causes (rate-limit/network) MUST keep a keyword it recognizes ("429",
       "network", …) in their friendly text; non-retryable causes must not. The
@@ -670,55 +672,55 @@ def friendly_download_error(raw_messages: Optional[List[str]]) -> Optional[str]:
     if not non_empty:
         return None
 
-    blob = " ".join(non_empty).lower()
+    lines = [m.lower() for m in non_empty]
 
-    # Age restriction is checked before the generic bot message because both
-    # begin with "Sign in to confirm ..." ("...your age" vs "...you're not a bot").
-    # Match specific phrases rather than a bare "age" substring, which would
-    # also fire on unrelated words ("storage", "message", "usage", …).
-    if ("confirm your age" in blob or "age-restricted" in blob
-            or "age restricted" in blob or "inappropriate for some users" in blob):
-        return "This video is age-restricted. Cookies from a signed-in, age-verified account are required."
+    # Each rule: (clauses, friendly_message). A line matches the rule if it
+    # satisfies ANY clause; a clause is a tuple of substrings that must ALL be
+    # present in that one line. Keeping AND-groups within a single line is what
+    # prevents cross-line keyword bleeding. Ordered most-specific first.
+    rules = [
+        # Age restriction — specific phrases, not a bare "age" (which would also
+        # fire on "storage", "message", "usage", …).
+        ([("confirm your age",), ("age-restricted",), ("age restricted",),
+          ("inappropriate for some users",)],
+         "This video is age-restricted. Cookies from a signed-in, age-verified account are required."),
+        # Bot detection / missing-expired cookies — the most common cause of
+        # "downloads stopped working" after a period of running fine.
+        ([("sign in to confirm",), ("not a bot",), ("confirm you", "bot")],
+         "YouTube blocked the download with a bot check. Your cookies are "
+         "likely missing or expired — export a fresh cookies file from a "
+         "signed-in browser session."),
+        # Video no longer downloadable for account/visibility reasons
+        ([("private video",)],
+         "This video is private and can no longer be downloaded."),
+        ([("video unavailable",), ("no longer available",), ("removed by the uploader",),
+          ("account associated",), ("has been terminated",)],
+         "This video is unavailable (deleted, removed, or the channel was terminated)."),
+        ([("members-only",), ("members only",), ("join this channel",)],
+         "This video is members-only and needs a channel membership (and matching cookies) to download."),
+        # Region / format issues
+        ([("available in your country",), ("blocked it in your country",), ("geo", "restrict")],
+         "This video is geo-blocked in your region and can't be downloaded from here."),
+        ([("requested format is not available",), ("requested format not available",)],
+         "The selected quality/format isn't available for this video. Try a different quality preset."),
+        # Stale yt-dlp vs. YouTube player changes — the fix is to update yt-dlp
+        ([("nsig",), ("unable to extract",), ("signature", "extract"), ("player", "extract")],
+         "YouTube changed its player and the installed yt-dlp can't decode this "
+         "video. Update yt-dlp (rebuild the container) and try again."),
+        # Transient conditions (must keep an is_retryable_error keyword)
+        ([("http error 429",), ("too many requests",)],
+         "YouTube is rate-limiting downloads (HTTP 429). Wait a while before retrying."),
+        ([("timed out",), ("timeout",), ("connection",), ("network",), ("getaddrinfo",),
+          ("temporary failure in name resolution",)],
+         "A network error interrupted the download. This is usually temporary — retry later."),
+    ]
 
-    # Bot detection / missing-expired cookies — by far the most common cause of
-    # "downloads stopped working" after a period of running fine.
-    if ("sign in to confirm" in blob or "not a bot" in blob
-            or ("confirm you" in blob and "bot" in blob)):
-        return ("YouTube blocked the download with a bot check. Your cookies are "
-                "likely missing or expired — export a fresh cookies file from a "
-                "signed-in browser session.")
+    def line_matches(line: str, clauses) -> bool:
+        return any(all(keyword in line for keyword in clause) for clause in clauses)
 
-    # Video no longer downloadable for account/visibility reasons
-    if "private video" in blob:
-        return "This video is private and can no longer be downloaded."
-    if ("video unavailable" in blob or "no longer available" in blob
-            or "removed by the uploader" in blob or "account associated" in blob
-            or "has been terminated" in blob):
-        return "This video is unavailable (deleted, removed, or the channel was terminated)."
-    if "members-only" in blob or "members only" in blob or "join this channel" in blob:
-        return "This video is members-only and needs a channel membership (and matching cookies) to download."
-
-    # Region / format issues
-    if ("available in your country" in blob or "blocked it in your country" in blob
-            or ("geo" in blob and "restrict" in blob)):
-        return "This video is geo-blocked in your region and can't be downloaded from here."
-    if "requested format is not available" in blob or "requested format not available" in blob:
-        return "The selected quality/format isn't available for this video. Try a different quality preset."
-
-    # Stale yt-dlp vs. YouTube player changes — the fix is to update yt-dlp
-    if ("nsig" in blob or "unable to extract" in blob
-            or ("signature" in blob and "extract" in blob)
-            or ("player" in blob and "extract" in blob)):
-        return ("YouTube changed its player and the installed yt-dlp can't decode this "
-                "video. Update yt-dlp (rebuild the container) and try again.")
-
-    # Transient conditions
-    if "http error 429" in blob or "too many requests" in blob:
-        return "YouTube is rate-limiting downloads (HTTP 429). Wait a while before retrying."
-    if ("timed out" in blob or "timeout" in blob or "connection" in blob
-            or "network" in blob or "getaddrinfo" in blob
-            or "temporary failure in name resolution" in blob):
-        return "A network error interrupted the download. This is usually temporary — retry later."
+    for clauses, message in rules:
+        if any(line_matches(line, clauses) for line in lines):
+            return message
 
     # We captured something we don't have a canned message for. Surfacing the
     # real (trimmed) yt-dlp line still beats an opaque "file not found".

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -11,7 +11,12 @@ import yt_dlp
 
 from app.models import Channel, Download, DownloadHistory
 from app.config import get_settings
-from app.utils import channel_dir_name, is_retryable_error
+from app.utils import (
+    channel_dir_name,
+    is_retryable_error,
+    YtdlpErrorCapture,
+    friendly_download_error,
+)
 from app.nfo_service import get_nfo_service
 from app.progress_store import download_progress_store
 from app.time_utils import utc_now
@@ -1068,6 +1073,12 @@ class VideoDownloadService:
             # progress store and stream yt-dlp progress into it
             download_progress_store.start(video_id, channel.id, channel.name, video_title)
             opts['progress_hooks'] = [download_progress_store.make_progress_hook(video_id)]
+            # Capture yt-dlp's real error output. Because ignoreerrors=True makes
+            # yt-dlp swallow failures (so one bad video doesn't abort the run),
+            # the actual reason is otherwise lost. Routing yt-dlp through this
+            # logger lets us translate the failure into a friendly message below.
+            error_capture = YtdlpErrorCapture(logger)
+            opts['logger'] = error_capture
             video_url = f"https://www.youtube.com/watch?v={video_id}"
 
             # Verify the cookie file referenced in options is still present on disk
@@ -1177,7 +1188,15 @@ class VideoDownloadService:
                 else:
                     # FAILURE: yt-dlp completed but no video file found
                     # This happens when yt-dlp encounters errors but doesn't throw (ignoreerrors=True)
-                    error_msg = "yt-dlp completed but video file not found on disk (check logs for yt-dlp errors)"
+                    #
+                    # Translate yt-dlp's captured error into a message the user
+                    # can act on (refresh cookies, update the app, etc.). If we
+                    # captured nothing recognizable, fall back to a generic hint
+                    # that points at DEBUG logging.
+                    error_msg = friendly_download_error(error_capture.messages) or (
+                        "Download finished but produced no video file, and yt-dlp "
+                        "reported no error. Enable DEBUG logging to see details."
+                    )
                     download.status = 'failed'
                     download.file_exists = False
                     download.error_message = error_msg[:500]
@@ -1187,16 +1206,19 @@ class VideoDownloadService:
                     return False, error_msg
                 
         except yt_dlp.DownloadError as e:
-            error_msg = str(e)
-            logger.warning(f"Download failed for {video_title} ({video_id}): {error_msg}")
-            
+            raw_msg = str(e)
+            # Prefer a friendly, actionable explanation; keep the raw yt-dlp
+            # text as the fallback so no detail is lost.
+            error_msg = friendly_download_error([raw_msg]) or f"Download error: {raw_msg}"
+            logger.warning(f"Download failed for {video_title} ({video_id}): {raw_msg}")
+
             # Update download record with error
             if 'download' in locals():
                 download.status = 'failed'
                 download.error_message = error_msg[:500]  # Truncate long error messages
                 db.commit()
-            
-            return False, f"Download error: {error_msg}"
+
+            return False, error_msg
             
         except Exception as e:
             error_msg = str(e)

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -1191,11 +1191,12 @@ class VideoDownloadService:
                     #
                     # Translate yt-dlp's captured error into a message the user
                     # can act on (refresh cookies, update the app, etc.). If we
-                    # captured nothing recognizable, fall back to a generic hint
-                    # that points at DEBUG logging.
+                    # captured nothing recognizable, fall back to a plainly worded
+                    # hint (this text is shown in the web UI, so keep it friendly).
                     error_msg = friendly_download_error(error_capture.messages) or (
-                        "Download finished but produced no video file, and yt-dlp "
-                        "reported no error. Enable DEBUG logging to see details."
+                        "The download didn't produce a video file and no reason was "
+                        "reported. Try again later; if it keeps happening, check the "
+                        "container logs for details."
                     )
                     download.status = 'failed'
                     download.file_exists = False

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -1222,6 +1222,10 @@ class VideoDownloadService:
             return False, error_msg
             
         except Exception as e:
+            # Deliberately NOT run through friendly_download_error(): that
+            # translator is tuned for yt-dlp's failure vocabulary, whereas this
+            # branch catches unexpected non-yt-dlp errors (bugs, I/O, DB) whose
+            # raw text is more useful verbatim for debugging.
             error_msg = str(e)
             logger.error(f"Unexpected error downloading {video_title} ({video_id}): {error_msg}")
 

--- a/backend/app/video_download_service.py
+++ b/backend/app/video_download_service.py
@@ -1208,8 +1208,14 @@ class VideoDownloadService:
                 
         except yt_dlp.DownloadError as e:
             raw_msg = str(e)
-            # Prefer a friendly, actionable explanation; keep the raw yt-dlp
-            # text as the fallback so no detail is lost.
+            # Translate only the RAISED exception text, deliberately NOT
+            # error_capture.messages. When yt-dlp actually raises, the exception
+            # is the authoritative fatal cause. Combining it with captured lines
+            # would be unsafe here: error_capture.messages returns warnings when
+            # no error() was captured, and per-line priority matching could then
+            # let a benign warning (e.g. "format is not available") outrank the
+            # raised cause and even flip its retryability. Keep raw yt-dlp text
+            # as the fallback so no detail is lost.
             error_msg = friendly_download_error([raw_msg]) or f"Download error: {raw_msg}"
             logger.warning(f"Download failed for {video_title} ({video_id}): {raw_msg}")
 

--- a/backend/tests/unit/test_friendly_download_error.py
+++ b/backend/tests/unit/test_friendly_download_error.py
@@ -93,6 +93,27 @@ class TestFriendlyDownloadError:
         # Falls through to the raw last-line fallback instead
         assert msg.startswith("Download failed:")
 
+    def test_no_bleeding_within_a_single_multiline_message(self):
+        # Same guarantee when the two keywords live on separate physical lines
+        # *within one* string (e.g. a multi-cause DownloadError). The message is
+        # split on newlines internally, so the geo rule must NOT fire.
+        msg = friendly_download_error([
+            "ERROR: failed to parse geo metadata field\n"
+            "ERROR: could not restrict output template"
+        ])
+        assert msg is not None
+        assert "geo-blocked" not in msg.lower()
+        # Fallback surfaces the terminal (last) line
+        assert "restrict output template" in msg.lower()
+
+    def test_multiline_message_still_classifies_real_cause(self):
+        # A genuine cause on one line of a multi-line string is still matched.
+        msg = friendly_download_error([
+            "ERROR: unable to download video data\n"
+            "ERROR: HTTP Error 429: Too Many Requests"
+        ])
+        assert "429" in msg or "rate" in msg.lower()
+
     # Guards the load-bearing invariant documented on friendly_download_error:
     # every translated message must round-trip through is_retryable_error() to
     # the correct retryable/non-retryable category. Runs one representative

--- a/backend/tests/unit/test_friendly_download_error.py
+++ b/backend/tests/unit/test_friendly_download_error.py
@@ -9,7 +9,7 @@ import logging
 
 import pytest
 
-from app.utils import YtdlpErrorCapture, friendly_download_error
+from app.utils import YtdlpErrorCapture, friendly_download_error, is_retryable_error
 
 
 class TestFriendlyDownloadError:
@@ -81,9 +81,15 @@ class TestYtdlpErrorCapture:
 
         assert cap.errors == ["ERROR: boom"]
         assert cap.warnings == ["WARNING: careful"]
-        # messages puts warnings first and errors last, so the fallback (which
-        # takes the last line) surfaces the real error, not an incidental warning
-        assert cap.messages == ["WARNING: careful", "ERROR: boom"]
+        # messages classifies on the error lines when any exist, so an
+        # incidental warning can't outrank the real cause
+        assert cap.messages == ["ERROR: boom"]
+
+    def test_messages_falls_back_to_warnings_when_no_error(self):
+        # When yt-dlp reports no ERROR (only warnings), classify on the warnings.
+        cap = YtdlpErrorCapture(logging.getLogger("test"))
+        cap.warning("WARNING: only a warning")
+        assert cap.messages == ["WARNING: only a warning"]
 
     def test_fallback_surfaces_error_not_warning(self):
         # A benign warning alongside an unrecognized fatal error: the friendly
@@ -94,6 +100,22 @@ class TestYtdlpErrorCapture:
         assert friendly_download_error(cap.messages) == (
             "Download failed: Some brand-new unrecognized failure"
         )
+
+    def test_colliding_warning_does_not_mask_retryable_error(self):
+        # Regression for the blob-matching pitfall: a benign warning whose text
+        # collides with an earlier, non-retryable branch ("format is not
+        # available") must NOT outrank the real transient error. Both the
+        # friendly message AND is_retryable_error must reflect the real cause,
+        # or the within-run retry would be silently skipped.
+        cap = YtdlpErrorCapture(logging.getLogger("test"))
+        cap.warning("WARNING: Requested format is not available. Falling back.")
+        cap.error("ERROR: Unable to download webpage: The read operation timed out")
+
+        friendly = friendly_download_error(cap.messages)
+        assert "network" in friendly.lower()
+        assert "format" not in friendly.lower()
+        # The translated message preserves retryability for the retry layer
+        assert is_retryable_error(friendly) is True
 
     def test_capture_feeds_translator(self):
         cap = YtdlpErrorCapture(logging.getLogger("test"))

--- a/backend/tests/unit/test_friendly_download_error.py
+++ b/backend/tests/unit/test_friendly_download_error.py
@@ -79,6 +79,20 @@ class TestFriendlyDownloadError:
         ])
         assert "private" in msg.lower()
 
+    def test_no_cross_line_keyword_bleeding(self):
+        # A two-keyword rule (geo needs "geo" AND "restrict") must not be
+        # satisfied by keywords coming from two *different*, unrelated lines.
+        # Here "geo" and "restrict" each appear in a separate line that does not
+        # describe a geo-block, so the geo rule must NOT fire.
+        msg = friendly_download_error([
+            "ERROR: failed to parse geo metadata field",
+            "ERROR: could not restrict output template",
+        ])
+        assert msg is not None
+        assert "geo-blocked" not in msg.lower()
+        # Falls through to the raw last-line fallback instead
+        assert msg.startswith("Download failed:")
+
     # Guards the load-bearing invariant documented on friendly_download_error:
     # every translated message must round-trip through is_retryable_error() to
     # the correct retryable/non-retryable category. Runs one representative

--- a/backend/tests/unit/test_friendly_download_error.py
+++ b/backend/tests/unit/test_friendly_download_error.py
@@ -56,6 +56,21 @@ class TestFriendlyDownloadError:
         msg = friendly_download_error(["WARNING: [youtube] Some videos may not be available: nsig extraction failed"])
         assert "update" in msg.lower()
 
+    def test_stale_player_matches_with_player_context(self):
+        msg = friendly_download_error(["ERROR: Unable to extract player response"])
+        assert "update" in msg.lower()
+
+    def test_unrelated_unable_to_extract_does_not_claim_stale_player(self):
+        # A bare "unable to extract" (here for uploader id) must NOT be labeled a
+        # stale-player issue, and — critically — must not strip the retry keyword
+        # from a line that also carries a transient signal. The stale-player rule
+        # is higher priority than the network/rate-limit rules, so this pins that
+        # tightening the clause keeps a colliding retryable error retryable.
+        msg = friendly_download_error(["ERROR: unable to extract uploader id; HTTP Error 429: Too Many Requests"])
+        assert "update yt-dlp" not in msg.lower()
+        assert "429" in msg or "rate" in msg.lower()
+        assert is_retryable_error(msg) is True
+
     def test_rate_limit(self):
         msg = friendly_download_error(["ERROR: HTTP Error 429: Too Many Requests"])
         assert "429" in msg or "rate" in msg.lower()

--- a/backend/tests/unit/test_friendly_download_error.py
+++ b/backend/tests/unit/test_friendly_download_error.py
@@ -81,8 +81,19 @@ class TestYtdlpErrorCapture:
 
         assert cap.errors == ["ERROR: boom"]
         assert cap.warnings == ["WARNING: careful"]
-        # messages puts errors first (most explanatory), then warnings
-        assert cap.messages == ["ERROR: boom", "WARNING: careful"]
+        # messages puts warnings first and errors last, so the fallback (which
+        # takes the last line) surfaces the real error, not an incidental warning
+        assert cap.messages == ["WARNING: careful", "ERROR: boom"]
+
+    def test_fallback_surfaces_error_not_warning(self):
+        # A benign warning alongside an unrecognized fatal error: the friendly
+        # fallback must report the error, never the warning.
+        cap = YtdlpErrorCapture(logging.getLogger("test"))
+        cap.warning("WARNING: Unable to download thumbnail")
+        cap.error("ERROR: Some brand-new unrecognized failure")
+        assert friendly_download_error(cap.messages) == (
+            "Download failed: Some brand-new unrecognized failure"
+        )
 
     def test_capture_feeds_translator(self):
         cap = YtdlpErrorCapture(logging.getLogger("test"))

--- a/backend/tests/unit/test_friendly_download_error.py
+++ b/backend/tests/unit/test_friendly_download_error.py
@@ -79,6 +79,28 @@ class TestFriendlyDownloadError:
         ])
         assert "private" in msg.lower()
 
+    # Guards the load-bearing invariant documented on friendly_download_error:
+    # every translated message must round-trip through is_retryable_error() to
+    # the correct retryable/non-retryable category. Runs one representative
+    # input per branch so a reworded message that drops (or wrongly gains) a
+    # retry keyword fails here instead of silently breaking the retry layer.
+    @pytest.mark.parametrize("raw,expect_retryable", [
+        ("ERROR: Sign in to confirm you're not a bot", False),
+        ("ERROR: Sign in to confirm your age", False),
+        ("ERROR: Private video", False),
+        ("ERROR: Video unavailable", False),
+        ("ERROR: Join this channel to get access to members-only content", False),
+        ("ERROR: The uploader has not made this video available in your country", False),
+        ("ERROR: Requested format is not available", False),
+        ("ERROR: nsig extraction failed", False),
+        ("ERROR: HTTP Error 429: Too Many Requests", True),
+        ("ERROR: Unable to download webpage: The read operation timed out", True),
+    ])
+    def test_retryability_preserved_per_branch(self, raw, expect_retryable):
+        friendly = friendly_download_error([raw])
+        assert friendly is not None
+        assert is_retryable_error(friendly) is expect_retryable
+
 
 class TestYtdlpErrorCapture:
     """YtdlpErrorCapture records yt-dlp's error/warning output for inspection."""

--- a/backend/tests/unit/test_friendly_download_error.py
+++ b/backend/tests/unit/test_friendly_download_error.py
@@ -68,6 +68,17 @@ class TestFriendlyDownloadError:
         msg = friendly_download_error(["ERROR: Something totally unexpected happened"])
         assert msg == "Download failed: Something totally unexpected happened"
 
+    def test_multiple_conflicting_error_lines_follow_branch_priority(self):
+        # When more than one error line is passed with conflicting keywords,
+        # branch priority (not line order) decides. "private video" outranks the
+        # network branch regardless of which line came first. This documents the
+        # single-cause-per-video assumption in friendly_download_error.
+        msg = friendly_download_error([
+            "ERROR: The read operation timed out",
+            "ERROR: Private video. Sign in if you've been granted access.",
+        ])
+        assert "private" in msg.lower()
+
 
 class TestYtdlpErrorCapture:
     """YtdlpErrorCapture records yt-dlp's error/warning output for inspection."""

--- a/backend/tests/unit/test_friendly_download_error.py
+++ b/backend/tests/unit/test_friendly_download_error.py
@@ -8,6 +8,7 @@ short, actionable message for the UI — the piece that replaces the opaque
 import logging
 
 import pytest
+import yt_dlp
 
 from app.utils import YtdlpErrorCapture, friendly_download_error, is_retryable_error
 
@@ -203,4 +204,58 @@ class TestYtdlpErrorCapture:
     def test_capture_feeds_translator(self):
         cap = YtdlpErrorCapture(logging.getLogger("test"))
         cap.error("ERROR: [youtube] abc: Sign in to confirm you're not a bot")
+        assert "cookies" in friendly_download_error(cap.messages).lower()
+
+
+class TestRealYtdlpDispatch:
+    """Validate the load-bearing assumption against the *installed* yt-dlp.
+
+    The whole feature relies on yt-dlp routing its error/warning output to our
+    custom `logger` even under the production options (`quiet=True`,
+    `no_warnings=True`, `ignoreerrors=True`). That dispatch is internal to
+    yt-dlp and has shifted across releases, and requirements.txt pins a floating
+    `>=` version — so these tests drive a REAL yt_dlp.YoutubeDL (no network:
+    they call yt-dlp's own report_error/report_warning, the same methods
+    extractors use) and fail loudly if a future version stops calling the
+    custom logger, instead of silently degrading to the generic message in
+    production while mocked unit tests stay green.
+    """
+
+    def _prod_ydl(self, capture):
+        # Mirror the quiet/no_warnings/ignoreerrors combo used in
+        # VideoDownloadService.download_opts for non-DEBUG operation.
+        return yt_dlp.YoutubeDL({
+            "quiet": True,
+            "no_warnings": True,
+            "ignoreerrors": True,
+            "logger": capture,
+        })
+
+    def test_report_error_reaches_custom_logger_under_prod_opts(self):
+        cap = YtdlpErrorCapture(logging.getLogger("test"))
+        ydl = self._prod_ydl(cap)
+        ydl.report_error("Sign in to confirm you're not a bot")
+
+        # The fatal cause must land in errors (not be swallowed by quiet), and
+        # translate to the actionable cookies message.
+        assert cap.errors, "yt-dlp did not route report_error() to the custom logger"
+        assert "cookies" in friendly_download_error(cap.messages).lower()
+
+    def test_report_warning_reaches_custom_logger_under_prod_opts(self):
+        cap = YtdlpErrorCapture(logging.getLogger("test"))
+        ydl = self._prod_ydl(cap)
+        ydl.report_warning("Unable to download thumbnail")
+
+        # Even with no_warnings=True, the custom logger receives warnings; they
+        # are captured for fallback use when no error() line is present.
+        assert cap.warnings, "yt-dlp did not route report_warning() to the custom logger"
+
+    def test_error_wins_over_warning_end_to_end_with_real_ydl(self):
+        # A benign warning plus a fatal error, both dispatched by a real
+        # YoutubeDL: the error must drive classification, not the warning.
+        cap = YtdlpErrorCapture(logging.getLogger("test"))
+        ydl = self._prod_ydl(cap)
+        ydl.report_warning("Unable to download thumbnail")
+        ydl.report_error("Sign in to confirm you're not a bot")
+
         assert "cookies" in friendly_download_error(cap.messages).lower()

--- a/backend/tests/unit/test_friendly_download_error.py
+++ b/backend/tests/unit/test_friendly_download_error.py
@@ -1,0 +1,90 @@
+"""Unit tests for friendly download-error translation (utils).
+
+These cover the logic that turns yt-dlp's raw, technical error output into a
+short, actionable message for the UI — the piece that replaces the opaque
+"video file not found on disk" symptom users used to see.
+"""
+
+import logging
+
+import pytest
+
+from app.utils import YtdlpErrorCapture, friendly_download_error
+
+
+class TestFriendlyDownloadError:
+    """friendly_download_error() maps raw yt-dlp text to human-friendly reasons."""
+
+    def test_returns_none_for_empty_input(self):
+        assert friendly_download_error([]) is None
+        assert friendly_download_error(None) is None
+        assert friendly_download_error(["", "   "]) is None
+
+    def test_bot_check_maps_to_cookies_message(self):
+        msg = friendly_download_error([
+            'ERROR: [youtube] abc: Sign in to confirm you’re not a bot.'
+        ])
+        assert msg is not None
+        assert "cookies" in msg.lower()
+
+    def test_private_video(self):
+        msg = friendly_download_error(["ERROR: [youtube] xyz: Private video"])
+        assert "private" in msg.lower()
+
+    def test_unavailable_video(self):
+        msg = friendly_download_error(["ERROR: Video unavailable"])
+        assert "unavailable" in msg.lower()
+
+    def test_members_only(self):
+        msg = friendly_download_error(["ERROR: Join this channel to get access to members-only content"])
+        assert "members-only" in msg.lower() or "membership" in msg.lower()
+
+    def test_age_restricted(self):
+        msg = friendly_download_error(["ERROR: Sign in to confirm your age. This video may be inappropriate for some users."])
+        # Age wording takes priority over the generic bot message
+        assert "age" in msg.lower()
+
+    def test_geo_block(self):
+        msg = friendly_download_error(["ERROR: The uploader has not made this video available in your country"])
+        assert "geo" in msg.lower() or "region" in msg.lower()
+
+    def test_format_unavailable(self):
+        msg = friendly_download_error(["ERROR: Requested format is not available"])
+        assert "format" in msg.lower() or "quality" in msg.lower()
+
+    def test_stale_player_nsig(self):
+        msg = friendly_download_error(["WARNING: [youtube] Some videos may not be available: nsig extraction failed"])
+        assert "update" in msg.lower()
+
+    def test_rate_limit(self):
+        msg = friendly_download_error(["ERROR: HTTP Error 429: Too Many Requests"])
+        assert "429" in msg or "rate" in msg.lower()
+
+    def test_network_error(self):
+        msg = friendly_download_error(["ERROR: Unable to download webpage: The read operation timed out"])
+        assert "network" in msg.lower() or "temporary" in msg.lower()
+
+    def test_unknown_error_surfaces_trimmed_raw_line(self):
+        msg = friendly_download_error(["ERROR: Something totally unexpected happened"])
+        assert msg == "Download failed: Something totally unexpected happened"
+
+
+class TestYtdlpErrorCapture:
+    """YtdlpErrorCapture records yt-dlp's error/warning output for inspection."""
+
+    def test_records_errors_and_warnings(self):
+        cap = YtdlpErrorCapture(logging.getLogger("test"))
+        cap.error("ERROR: boom")
+        cap.warning("WARNING: careful")
+        cap.info("just info")
+        cap.debug("just debug")
+
+        assert cap.errors == ["ERROR: boom"]
+        assert cap.warnings == ["WARNING: careful"]
+        # messages puts errors first (most explanatory), then warnings
+        assert cap.messages == ["ERROR: boom", "WARNING: careful"]
+
+    def test_capture_feeds_translator(self):
+        cap = YtdlpErrorCapture(logging.getLogger("test"))
+        cap.error("ERROR: [youtube] abc: Sign in to confirm you're not a bot")
+        assert "cookies" in friendly_download_error(cap.messages).lower()

--- a/backend/tests/unit/test_video_download_service.py
+++ b/backend/tests/unit/test_video_download_service.py
@@ -285,10 +285,12 @@ class TestVideoDownloadService:
         video_info = sample_video_info[0]
         
         success, error = service.download_video(video_info, test_channel, mock_db)
-        
+
         assert success is False
-        assert "Video unavailable" in error
-        
+        # yt-dlp's raw "Video unavailable" is now translated into a friendly,
+        # user-facing explanation (see utils.friendly_download_error)
+        assert "unavailable" in error.lower()
+
         # Verify error was stored in database
         mock_db.add.assert_called()
         mock_db.commit.assert_called()

--- a/backend/tests/unit/test_video_download_service.py
+++ b/backend/tests/unit/test_video_download_service.py
@@ -295,6 +295,44 @@ class TestVideoDownloadService:
         mock_db.add.assert_called()
         mock_db.commit.assert_called()
 
+    @patch('app.video_download_service.yt_dlp.YoutubeDL')
+    def test_download_video_swallowed_error_surfaces_friendly_message(
+        self, mock_ydl_class, mock_settings, test_channel, mock_db, sample_video_info
+    ):
+        """The core PR scenario: ignoreerrors=True lets ydl.download() return
+        normally while producing no file. The error yt-dlp routed through the
+        capture logger must be translated into the user-facing message, proving
+        the logger is wired into opts before download() and read afterward.
+        """
+        # Deliberately create NO video file, so _find_video_file_path returns
+        # None and the "file not found" failure branch runs.
+        mock_ydl = Mock()
+        mock_ydl_class.return_value.__enter__.return_value = mock_ydl
+
+        def fake_download(urls):
+            # Retrieve the capture logger the service injected into opts and
+            # emit output the way yt-dlp would with ignoreerrors=True (no raise).
+            opts = mock_ydl_class.call_args[0][0]
+            capture = opts['logger']
+            capture.warning("WARNING: Unable to download thumbnail")
+            capture.error("ERROR: [youtube] abc: Sign in to confirm you're not a bot")
+            return None  # yt-dlp swallowed the error, returns normally
+
+        mock_ydl.download.side_effect = fake_download
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        service = VideoDownloadService()
+        video_info = sample_video_info[0]
+
+        success, error = service.download_video(video_info, test_channel, mock_db)
+
+        assert success is False
+        # The recognized bot-check error flows through to the friendly message,
+        # not the opaque "file not found" text and not the incidental warning.
+        assert "cookies" in error.lower()
+        assert "thumbnail" not in error.lower()
+        assert "not found on disk" not in error.lower()
+
     @patch('app.video_download_service.VideoDownloadService.get_recent_videos')
     @patch('app.video_download_service.VideoDownloadService.download_video')
     def test_process_channel_downloads_success(self, mock_download_video, mock_get_recent_videos, 


### PR DESCRIPTION
## Summary
When yt-dlp encounters download failures (bot checks, private videos, geo-blocks, etc.), it normally swallows the error internally due to `ignoreerrors=True` in our download options. This left users with only an opaque "file not found" message. This PR captures yt-dlp's actual error/warning output and translates it into actionable, human-friendly explanations.

## Key Changes

- **New `YtdlpErrorCapture` class** (`app/utils.py`): A custom logger that yt-dlp can route its messages through, capturing error and warning lines while forwarding everything to the app logger at DEBUG level. This preserves the real failure reason that would otherwise be lost.

- **New `friendly_download_error()` function** (`app/utils.py`): Translates raw yt-dlp technical output into short, actionable messages. Maps common failure patterns to user-facing explanations:
  - Bot checks → "refresh your cookies"
  - Private/unavailable videos → "video is private/deleted"
  - Age restrictions → "age-verified account required"
  - Geo-blocks → "region blocked"
  - Format unavailable → "try different quality"
  - Stale player code → "update yt-dlp"
  - Rate limiting → "wait before retrying"
  - Network errors → "temporary, retry later"
  - Unknown errors → surfaces the trimmed raw yt-dlp line as fallback

- **Integration in `video_download_service.py`**: 
  - Plugs `YtdlpErrorCapture` into yt-dlp's logger option during downloads
  - Uses `friendly_download_error()` to translate captured messages into user-facing error text
  - Falls back to a helpful generic message if no recognizable error was captured
  - Applies the same translation logic to explicit `DownloadError` exceptions

- **Comprehensive unit tests** (`tests/unit/test_friendly_download_error.py`): 
  - Tests empty/null input handling
  - Validates each major error pattern maps to the correct friendly message
  - Confirms the capture → translation pipeline works end-to-end

## Implementation Details

The solution is intentionally keyword-based rather than regex-heavy, since yt-dlp's wording shifts between releases. Rules are ordered from most specific/most common to least, with age-restriction checked before the generic bot message (both start with "Sign in to confirm...").

Error messages are truncated to 500 characters when stored in the database, and all yt-dlp output is logged at DEBUG level so nothing is silently dropped even when a friendly translation is shown to the user.

https://claude.ai/code/session_014jjFftub8ziEiyaLct8v2r